### PR TITLE
docs: add API key guide link to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Plug Venice's chat, image, video, audio, music, and character models into any ag
 
 ### 1. Get a key from [venice.ai](https://venice.ai)
 
+See the [API key guide](https://docs.venice.ai/guides/getting-started/generating-api-key) for step-by-step instructions.
+
 ### 2. Add this to your MCP host config
 
 **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows), **Cursor** (`~/.cursor/mcp.json`), **LM Studio**, etc:


### PR DESCRIPTION
Adds a link to the Venice API key guide (https://docs.venice.ai/guides/getting-started/generating-api-key) in the Quick Start section so users know exactly where to get their key.