### PR TITLE
docs: remove unimplemented FAQ entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,11 +362,6 @@ No. The simple path is `VENICE_API_KEY` + a normal Venice account. x402 is an *o
 **Where does the wallet's private key live?**
 Not in this server. You sign the SIWE message + USDC top-up authorizations in your own wallet (MetaMask, Coinbase Wallet, viem-script, etc.). The server only sees the resulting SIWX token and never sees a private key.
 
-**Can my agent self-rate-limit?**
-Pass `X-Venice-Max-Cost: 0.05` (USDC) on requests via your client; Venice will 402 with a `cost_cap_exceeded` reason before running expensive jobs.
-
-**What's the Venice receiver wallet?**
-`0x2670B922ef37C7Df47158725C0CC407b5382293F` on Base mainnet. Top-ups are USDC. (Check the live `topUpInstructions` in the 402 response — this is the source of truth.)
 
 **Minimum top-up?**
 $5 USD (anti-dust). Minimum balance to call inference is $0.10. Default suggested top-up is $10.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ No email, phone, or KYC if you go the SIWX path. The wallet ↔ credit account m
 **DIEM staking?**
 If your wallet is linked to a Venice user with DIEM staked, calls consume from the staking balance instead of USDC credits — no top-up needed.
 
+**Getting 402 errors even though I have an API key?**
+The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP server process. Most MCP hosts (Claude Desktop, Cursor, Codex, etc.) only pass environment variables that are **explicitly listed** in the `"env"` block of your MCP config — system-level env vars are not automatically inherited. Make sure your config looks like this:
+```json
+{
+  "mcpServers": {
+    "venice": {
+      "command": "npx",
+      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
+    }
+  }
+}
+```
+If the key is missing or blank, the server falls back to x402 mode and returns a 402 payment challenge.
+
 ---
 
 ## Disclaimer


### PR DESCRIPTION
Removes two FAQ entries that reference features not yet implemented or not relevant to MCP users:
- 'Can my agent self-rate-limit?' — references X-Venice-Max-Cost header which is not live
- 'What's the Venice receiver wallet?' — hardcoded wallet address, not appropriate for public docs