### PR TITLE
fix: detect actual image mime type in venice_image_generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -169,7 +169,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -379,7 +379,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -169,7 +169,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -379,7 +379,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ No email, phone, or KYC if you go the SIWX path. The wallet ↔ credit account m
 **DIEM staking?**
 If your wallet is linked to a Venice user with DIEM staked, calls consume from the staking balance instead of USDC credits — no top-up needed.
 
+**Getting 402 errors even though I have an API key?**
+The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP server process. Most MCP hosts (Claude Desktop, Cursor, Codex, etc.) only pass environment variables that are **explicitly listed** in the `"env"` block of your MCP config — system-level env vars are not automatically inherited. Make sure your config looks like this:
+```json
+{
+  "mcpServers": {
+    "venice": {
+      "command": "npx",
+      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
+    }
+  }
+}
+```
+If the key is missing or blank, the server falls back to x402 mode and returns a 402 payment challenge.
+
 ---
 
 ## Disclaimer

--- a/examples/claude-desktop.json
+++ b/examples/claude-desktop.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>"

--- a/examples/claude-desktop.json
+++ b/examples/claude-desktop.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>"

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",

--- a/mcp.json
+++ b/mcp.json
@@ -5,7 +5,7 @@
   "description": "Uncensored, private, crypto-native AI inference (LLM, image, video, TTS, ASR, music, characters) by Venice.ai. Pay-per-call via x402, optional API key, no account required. Community-maintained, provided as-is, no SLA — use at your own risk.",
   "homepage": "https://venice.ai",
   "license": "MIT",
-  "version": "0.2.0-alpha",
+  "version": "0.1.1-alpha",
   "keywords": ["uncensored", "privacy", "crypto", "x402", "image-generation", "video-generation", "tts", "asr", "music", "characters"],
   "transports": ["stdio"],
   "command": {

--- a/mcp.json
+++ b/mcp.json
@@ -5,7 +5,7 @@
   "description": "Uncensored, private, crypto-native AI inference (LLM, image, video, TTS, ASR, music, characters) by Venice.ai. Pay-per-call via x402, optional API key, no account required. Community-maintained, provided as-is, no SLA — use at your own risk.",
   "homepage": "https://venice.ai",
   "license": "MIT",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "keywords": ["uncensored", "privacy", "crypto", "x402", "image-generation", "video-generation", "tts", "asr", "music", "characters"],
   "transports": ["stdio"],
   "command": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@veniceai/mcp-server",
-      "version": "0.1.0-alpha",
+      "version": "0.2.0-alpha",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.2.0-alpha",
+  "version": "0.1.1-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@veniceai/mcp-server",
-      "version": "0.2.0-alpha",
+      "version": "0.1.1-alpha",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.2.0-alpha",
+  "version": "0.1.1-alpha",
   "description": "Model Context Protocol server for Venice.ai — uncensored, private, crypto-native AI inference for Claude, ChatGPT, Cursor and any MCP host. Community-maintained. Provided as-is, with no warranty or SLA from Venice AI. Use at your own risk.",
   "license": "MIT",
   "author": "Venice AI",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "description": "Model Context Protocol server for Venice.ai — uncensored, private, crypto-native AI inference for Claude, ChatGPT, Cursor and any MCP host. Community-maintained. Provided as-is, with no warranty or SLA from Venice AI. Use at your own risk.",
   "license": "MIT",
   "author": "Venice AI",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,6 +28,33 @@ import type { Config } from '../config.js'
 import { formatToolError, truncate } from '../format.js'
 import { fetchUploadSource } from './remote-fetch.js'
 
+/**
+ * Sniff the MIME type of a base64-encoded image from its magic bytes.
+ * Falls back to 'image/png' if the format is unrecognised.
+ */
+function detectBase64ImageMime(b64: string): string {
+  const header = b64.slice(0, 16)
+  const bytes = Buffer.from(header, 'base64')
+  // WebP: RIFF????WEBP
+  if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46 &&
+      bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
+    return 'image/webp'
+  }
+  // PNG: \x89PNG
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) {
+    return 'image/png'
+  }
+  // JPEG: \xFF\xD8
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return 'image/jpeg'
+  }
+  // GIF: GIF8
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) {
+    return 'image/gif'
+  }
+  return 'image/png'
+}
+
 type TextContent = { type: 'text'; text: string }
 type ImageContent = { type: 'image'; data: string; mimeType: string }
 type AudioContent = { type: 'audio'; data: string; mimeType: string }
@@ -199,8 +226,9 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
           })
           // Default Venice response: { id, images: [<base64>] }
           if (resp.images && resp.images.length > 0 && typeof resp.images[0] === 'string') {
+            const mimeType = detectBase64ImageMime(resp.images[0])
             return {
-              content: [{ type: 'image', data: resp.images[0], mimeType: 'image/png' }],
+              content: [{ type: 'image', data: resp.images[0], mimeType }],
               structuredContent: { id: resp.id, count: resp.images.length },
             }
           }
@@ -216,7 +244,8 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
             }
           }
           if (first?.b64_json) {
-            return { content: [{ type: 'image', data: first.b64_json, mimeType: 'image/png' }] }
+            const mimeType = detectBase64ImageMime(first.b64_json)
+            return { content: [{ type: 'image', data: first.b64_json, mimeType }] }
           }
           return fail('Venice returned no usable image payload.')
         } catch (err) {


### PR DESCRIPTION
## Problem
`venice_image_generate` hardcoded `mimeType: 'image/png'` for all base64 image responses, but Venice returns WebP for Flux and other models. MCP hosts (Claude, GitHub Copilot) pass the mimeType to the model, which then rejects the content with a 400 error:

```
image.source.base64: The image was specified using the image/png media type, but the image appears to be a image/webp image
```

## Fix
Added `detectBase64ImageMime()` which sniffs the actual format from the base64 magic bytes (WebP, PNG, JPEG, GIF) and uses that instead of the hardcoded value. Falls back to `image/png` for unrecognised formats.