### PR TITLE
chore: bump version to 0.2.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -169,7 +169,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -379,7 +379,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ No email, phone, or KYC if you go the SIWX path. The wallet ↔ credit account m
 **DIEM staking?**
 If your wallet is linked to a Venice user with DIEM staked, calls consume from the staking balance instead of USDC credits — no top-up needed.
 
+**Getting 402 errors even though I have an API key?**
+The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP server process. Most MCP hosts (Claude Desktop, Cursor, Codex, etc.) only pass environment variables that are **explicitly listed** in the `"env"` block of your MCP config — system-level env vars are not automatically inherited. Make sure your config looks like this:
+```json
+{
+  "mcpServers": {
+    "venice": {
+      "command": "npx",
+      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
+    }
+  }
+}
+```
+If the key is missing or blank, the server falls back to x402 mode and returns a 402 payment challenge.
+
 ---
 
 ## Disclaimer

--- a/examples/claude-desktop.json
+++ b/examples/claude-desktop.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>"

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0-alpha"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",

--- a/mcp.json
+++ b/mcp.json
@@ -5,7 +5,7 @@
   "description": "Uncensored, private, crypto-native AI inference (LLM, image, video, TTS, ASR, music, characters) by Venice.ai. Pay-per-call via x402, optional API key, no account required. Community-maintained, provided as-is, no SLA — use at your own risk.",
   "homepage": "https://venice.ai",
   "license": "MIT",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "keywords": ["uncensored", "privacy", "crypto", "x402", "image-generation", "video-generation", "tts", "asr", "music", "characters"],
   "transports": ["stdio"],
   "command": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@veniceai/mcp-server",
-      "version": "0.1.0-alpha",
+      "version": "0.2.0-alpha",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0-alpha",
   "description": "Model Context Protocol server for Venice.ai — uncensored, private, crypto-native AI inference for Claude, ChatGPT, Cursor and any MCP host. Community-maintained. Provided as-is, with no warranty or SLA from Venice AI. Use at your own risk.",
   "license": "MIT",
   "author": "Venice AI",


### PR DESCRIPTION
Bumps version to 0.2.0-alpha across package.json, package-lock.json, mcp.json, README and examples.