### PR TITLE
fix: remove broken npm install step in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,9 +48,6 @@ jobs:
           node-version: 22
           registry-url: ${{ env.REGISTRY_URL }}
 
-      - name: Use npm with trusted publishing support
-        run: npm install -g npm@latest
-
       - name: Set package version
         id: version
         shell: bash

--- a/README.md
+++ b/README.md
@@ -377,6 +377,21 @@ No email, phone, or KYC if you go the SIWX path. The wallet ↔ credit account m
 **DIEM staking?**
 If your wallet is linked to a Venice user with DIEM staked, calls consume from the staking balance instead of USDC credits — no top-up needed.
 
+**Getting 402 errors even though I have an API key?**
+The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP server process. Most MCP hosts (Claude Desktop, Cursor, Codex, etc.) only pass environment variables that are **explicitly listed** in the `"env"` block of your MCP config — system-level env vars are not automatically inherited. Make sure your config looks like this:
+```json
+{
+  "mcpServers": {
+    "venice": {
+      "command": "npx",
+      "args": ["-y", "@veniceai/mcp-server@0.1.0-alpha"],
+      "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
+    }
+  }
+}
+```
+If the key is missing or blank, the server falls back to x402 mode and returns a 402 payment challenge.
+
 ---
 
 ## Disclaimer


### PR DESCRIPTION
The `npm install -g npm@latest` step was failing with `MODULE_NOT_FOUND: promise-retry` on the GitHub Actions runner (Node 22.22.2). The runner already ships with a compatible npm — this step is unnecessary and was blocking all publishes.