### PR TITLE
harden HTTP transport and remote fetch security

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out release target
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
@@ -31,10 +31,12 @@ jobs:
       - name: Verify release target branch
         id: target
         shell: bash
+        env:
+          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
         run: |
           set -euo pipefail
 
-          target="${{ github.event.release.target_commitish }}"
+          target="$RELEASE_TARGET"
           if ! git ls-remote --exit-code --heads origin "$target" >/dev/null; then
             echo "::error::Release target '${target}' is not a branch. Refusing to publish because the version bump cannot be committed back safely."
             exit 1
@@ -43,7 +45,7 @@ jobs:
           echo "branch=${target}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: ${{ env.REGISTRY_URL }}
@@ -54,10 +56,12 @@ jobs:
       - name: Set package version
         id: version
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
 
-          release_tag="${{ github.event.release.tag_name }}"
+          release_tag="$RELEASE_TAG"
           semver_pattern='^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
 
           if [[ "$release_tag" =~ $semver_pattern ]]; then
@@ -99,11 +103,14 @@ jobs:
       - name: Check npm package version
         id: npm_status
         shell: bash
+        env:
+          PACKAGE_NAME: ${{ steps.version.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
           set -euo pipefail
 
-          package_name="${{ steps.version.outputs.package_name }}"
-          package_version="${{ steps.version.outputs.package_version }}"
+          package_name="$PACKAGE_NAME"
+          package_version="$PACKAGE_VERSION"
 
           if npm view "${package_name}@${package_version}" version --registry "$REGISTRY_URL" >/dev/null 2>&1; then
             echo "${package_name}@${package_version} already exists on npm; skipping publish."
@@ -115,10 +122,15 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm_status.outputs.exists != 'true'
-        run: npm publish --provenance --access public --tag "${{ steps.version.outputs.publish_tag }}"
+        env:
+          PUBLISH_TAG: ${{ steps.version.outputs.publish_tag }}
+        run: npm publish --provenance --access public --tag "$PUBLISH_TAG"
 
       - name: Commit version bump
         shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
+          TARGET_BRANCH: ${{ steps.target.outputs.branch }}
         run: |
           set -euo pipefail
 
@@ -127,10 +139,10 @@ jobs:
             exit 0
           fi
 
-          package_version="${{ steps.version.outputs.package_version }}"
+          package_version="$PACKAGE_VERSION"
 
           git add package.json package-lock.json
           git -c user.name="github-actions[bot]" \
             -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
             commit -m "chore: release v${package_version} [skip ci]"
-          git push origin "HEAD:${{ steps.target.outputs.branch }}"
+          git push origin "HEAD:${TARGET_BRANCH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ COPY package.json ./
 EXPOSE 3333
 ENV VENICE_MCP_HTTP=1
 # Container needs to bind all interfaces so the host port mapping reaches it.
+# HTTP startup requires VENICE_MCP_AUTH_TOKEN for this non-loopback bind unless
+# VENICE_MCP_ALLOW_UNAUTHENTICATED_HTTP=1 is set behind a trusted proxy.
 ENV VENICE_MCP_HOST=0.0.0.0
 USER node
 CMD ["node", "dist/cli.js", "--http"]

--- a/README.md
+++ b/README.md
@@ -132,15 +132,19 @@ npx -y @smithery/cli install venice
 | `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |
 | `VENICE_DISABLE_NSFW` | `0` | Set to `1` to remove NSFW capability notes from tool descriptions. |
 | `VENICE_HTTP_TIMEOUT_MS` | `60000` | |
-| `VENICE_API_BASE_URL` | `https://api.venice.ai/api` | Override for self-hosted Venice. `https://api.venice.ai` is normalized to this API root. |
+| `VENICE_API_BASE_URL` | `https://api.venice.ai/api` | Override for self-hosted Venice. `https://api.venice.ai` is normalized to this API root. Non-loopback URLs must use HTTPS unless `VENICE_ALLOW_INSECURE_API_BASE_URL=1` is set. |
+| `VENICE_ALLOW_INSECURE_API_BASE_URL` | `0` | Set to `1` only for deliberate private deployments that need a non-HTTPS upstream URL. |
 | `VENICE_SIWX_TOKEN` | _(none)_ | **x402** wallet-mode auth token — see [**x402** — pay with a wallet](#x402--pay-with-a-wallet-no-account-required). |
 | `PORT` | `3333` | HTTP-mode listener. |
 | `VENICE_MCP_HOST` | `127.0.0.1` | HTTP-mode bind address. Set to `0.0.0.0` for LAN/container exposure. |
-| `VENICE_MCP_AUTH_TOKEN` | _(none)_ | Optional bearer token required by `/mcp` in HTTP mode. Set this before publishing the HTTP port outside a trusted local boundary. |
+| `VENICE_MCP_AUTH_TOKEN` | _(none)_ | Bearer token required by `/mcp` whenever HTTP mode binds outside loopback. Use a long random value. |
+| `VENICE_MCP_ALLOW_UNAUTHENTICATED_HTTP` | `0` | Emergency escape hatch for unauthenticated exposed HTTP mode. Use only behind a trusted authenticated proxy. |
+| `VENICE_MCP_MAX_SESSIONS` | `100` | Maximum active Streamable HTTP sessions. |
+| `VENICE_MCP_SESSION_TTL_MS` | `1800000` | Idle Streamable HTTP session lifetime before cleanup. |
 
 ## Self-hosting (Streamable HTTP)
 
-`/mcp` is a credential-backed tool execution endpoint: callers can spend the configured Venice API key or x402 balance. If you publish the HTTP port, set `VENICE_MCP_AUTH_TOKEN` or put the service behind an authenticated reverse proxy.
+`/mcp` is a credential-backed tool execution endpoint: callers can spend the configured Venice API key or x402 balance. When HTTP mode binds outside loopback, startup fails unless `VENICE_MCP_AUTH_TOKEN` is set, or `VENICE_MCP_ALLOW_UNAUTHENTICATED_HTTP=1` is explicitly set behind a trusted authenticated proxy.
 
 ```bash
 docker run -p 3333:3333 \
@@ -150,7 +154,7 @@ docker run -p 3333:3333 \
 # server at http://localhost:3333/mcp
 ```
 
-Clients should send `Authorization: Bearer <choose-a-long-random-token>` with HTTP MCP requests. For reproducible production installs, pin the npm package version as shown in the examples instead of using an unversioned `latest` install path.
+Clients should send `Authorization: Bearer <choose-a-long-random-token>` with HTTP MCP requests. HTTP clients should create new sessions without an `mcp-session-id` header and then reuse the server-issued session ID; unknown or malformed caller-provided session IDs are rejected. For reproducible production installs, pin the npm package version as shown in the examples instead of using an unversioned `latest` install path.
 
 Or run from source — see [Development](#development) below.
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ npx -y @smithery/cli install venice
 | `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |
 | `VENICE_DISABLE_NSFW` | `0` | Set to `1` to remove NSFW capability notes from tool descriptions. |
 | `VENICE_HTTP_TIMEOUT_MS` | `60000` | |
-| `VENICE_API_BASE_URL` | `https://api.venice.ai/api` | Override for self-hosted Venice. `https://api.venice.ai` is normalized to this API root. Non-loopback URLs must use HTTPS unless `VENICE_ALLOW_INSECURE_API_BASE_URL=1` is set. |
-| `VENICE_ALLOW_INSECURE_API_BASE_URL` | `0` | Set to `1` only for deliberate private deployments that need a non-HTTPS upstream URL. |
 | `VENICE_SIWX_TOKEN` | _(none)_ | **x402** wallet-mode auth token — see [**x402** — pay with a wallet](#x402--pay-with-a-wallet-no-account-required). |
 | `PORT` | `3333` | HTTP-mode listener. |
 | `VENICE_MCP_HOST` | `127.0.0.1` | HTTP-mode bind address. Set to `0.0.0.0` for LAN/container exposure. |

--- a/examples/openwebui-streamable-http.md
+++ b/examples/openwebui-streamable-http.md
@@ -12,4 +12,4 @@ docker run --rm -p 3333:3333 \
 
 In Open WebUI: Settings → Tools → Add MCP Server → URL `http://localhost:3333/mcp` and send `Authorization: Bearer <choose-a-long-random-token>` if your client supports custom headers.
 
-Do not publish `/mcp` to an untrusted network without `VENICE_MCP_AUTH_TOKEN` or an authenticated reverse proxy; callers can invoke tools using the server's Venice credentials.
+The Docker image binds to `0.0.0.0`, so startup requires `VENICE_MCP_AUTH_TOKEN` by default. Do not publish `/mcp` to an untrusted network without that token or an authenticated reverse proxy; callers can invoke tools using the server's Venice credentials.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -13,10 +13,6 @@ startCommand:
         type: string
         title: Venice SIWX token
         description: Optional base64 SIWE payload for x402 wallet-mode auth. Used when VENICE_API_KEY is unset.
-      VENICE_API_BASE_URL:
-        type: string
-        title: API base URL
-        default: https://api.venice.ai/api
       VENICE_DEFAULT_CHAT_MODEL:
         type: string
         default: venice-uncensored
@@ -34,7 +30,6 @@ startCommand:
       env: {
         VENICE_API_KEY: config.VENICE_API_KEY ?? "",
         VENICE_SIWX_TOKEN: config.VENICE_SIWX_TOKEN ?? "",
-        VENICE_API_BASE_URL: config.VENICE_API_BASE_URL ?? "https://api.venice.ai/api",
         VENICE_DEFAULT_CHAT_MODEL: config.VENICE_DEFAULT_CHAT_MODEL ?? "venice-uncensored",
         VENICE_DEFAULT_IMAGE_MODEL: config.VENICE_DEFAULT_IMAGE_MODEL ?? "flux-2-pro",
         VENICE_DISABLE_NSFW: config.VENICE_DISABLE_NSFW ?? ""

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ export interface Config {
   serverVersion: string
 }
 
-export const VENICE_API_BASE_URL = 'https://api.venice.ai/api'
+const VENICE_API_BASE_URL = 'https://api.venice.ai/api'
 const DEFAULT_TIMEOUT_MS = 60_000
 
 function parseTimeoutMs(value: string | undefined): number {

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,11 +52,34 @@ export interface Config {
 const DEFAULT_BASE_URL = 'https://api.venice.ai/api'
 const DEFAULT_TIMEOUT_MS = 60_000
 
-function normalizeBaseUrl(value: string | undefined): string {
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase()
+  return normalized === 'localhost' || normalized.endsWith('.localhost') || normalized === '127.0.0.1' || normalized === '::1' || normalized.startsWith('127.')
+}
+
+function normalizeBaseUrl(value: string | undefined, env: NodeJS.ProcessEnv): string {
   const trimmed = value?.trim()
   if (!trimmed) return DEFAULT_BASE_URL
 
-  const withoutTrailingSlash = trimmed.replace(/\/+$/, '')
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    throw new Error('VENICE_API_BASE_URL must be an absolute URL')
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error('VENICE_API_BASE_URL must not include credentials')
+  }
+  if (parsed.protocol !== 'https:') {
+    const allowInsecure = env.VENICE_ALLOW_INSECURE_API_BASE_URL === '1'
+    const allowLoopback = parsed.protocol === 'http:' && isLoopbackHostname(parsed.hostname)
+    if (!allowInsecure && !allowLoopback) {
+      throw new Error('VENICE_API_BASE_URL must use https unless it points to loopback or VENICE_ALLOW_INSECURE_API_BASE_URL=1 is set')
+    }
+  }
+
+  const withoutTrailingSlash = parsed.href.replace(/\/+$/, '')
   if (withoutTrailingSlash === 'https://api.venice.ai') return DEFAULT_BASE_URL
   return withoutTrailingSlash
 }
@@ -68,7 +91,7 @@ function parseTimeoutMs(value: string | undefined): number {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   return {
-    baseUrl: normalizeBaseUrl(env.VENICE_API_BASE_URL),
+    baseUrl: normalizeBaseUrl(env.VENICE_API_BASE_URL, env),
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
     defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored',

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,7 +59,8 @@ function parseTimeoutMs(value: string | undefined): number {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   return {
-    baseUrl: VENICE_API_BASE_URL,
+    // VENICE_TEST_BASE_URL is an internal test-only escape hatch — never documented publicly.
+    baseUrl: env.VENICE_TEST_BASE_URL?.trim() || VENICE_API_BASE_URL,
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
     defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored',

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,6 @@ export interface Config {
   serverVersion: string
 }
 
-const VENICE_API_BASE_URL = 'https://api.venice.ai/api'
 const DEFAULT_TIMEOUT_MS = 60_000
 
 function parseTimeoutMs(value: string | undefined): number {
@@ -60,7 +59,7 @@ function parseTimeoutMs(value: string | undefined): number {
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   return {
     // VENICE_TEST_BASE_URL is an internal test-only escape hatch — never documented publicly.
-    baseUrl: env.VENICE_TEST_BASE_URL?.trim() || VENICE_API_BASE_URL,
+    baseUrl: env.VENICE_TEST_BASE_URL?.trim() || 'https://api.venice.ai/api',
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
     defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored',

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,40 +49,8 @@ export interface Config {
   serverVersion: string
 }
 
-const DEFAULT_BASE_URL = 'https://api.venice.ai/api'
+export const VENICE_API_BASE_URL = 'https://api.venice.ai/api'
 const DEFAULT_TIMEOUT_MS = 60_000
-
-function isLoopbackHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase()
-  return normalized === 'localhost' || normalized.endsWith('.localhost') || normalized === '127.0.0.1' || normalized === '::1' || normalized.startsWith('127.')
-}
-
-function normalizeBaseUrl(value: string | undefined, env: NodeJS.ProcessEnv): string {
-  const trimmed = value?.trim()
-  if (!trimmed) return DEFAULT_BASE_URL
-
-  let parsed: URL
-  try {
-    parsed = new URL(trimmed)
-  } catch {
-    throw new Error('VENICE_API_BASE_URL must be an absolute URL')
-  }
-
-  if (parsed.username || parsed.password) {
-    throw new Error('VENICE_API_BASE_URL must not include credentials')
-  }
-  if (parsed.protocol !== 'https:') {
-    const allowInsecure = env.VENICE_ALLOW_INSECURE_API_BASE_URL === '1'
-    const allowLoopback = parsed.protocol === 'http:' && isLoopbackHostname(parsed.hostname)
-    if (!allowInsecure && !allowLoopback) {
-      throw new Error('VENICE_API_BASE_URL must use https unless it points to loopback or VENICE_ALLOW_INSECURE_API_BASE_URL=1 is set')
-    }
-  }
-
-  const withoutTrailingSlash = parsed.href.replace(/\/+$/, '')
-  if (withoutTrailingSlash === 'https://api.venice.ai') return DEFAULT_BASE_URL
-  return withoutTrailingSlash
-}
 
 function parseTimeoutMs(value: string | undefined): number {
   const parsed = Number(value ?? DEFAULT_TIMEOUT_MS)
@@ -91,7 +59,7 @@ function parseTimeoutMs(value: string | undefined): number {
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   return {
-    baseUrl: normalizeBaseUrl(env.VENICE_API_BASE_URL, env),
+    baseUrl: VENICE_API_BASE_URL,
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
     defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored',

--- a/src/tools/remote-fetch.ts
+++ b/src/tools/remote-fetch.ts
@@ -1,11 +1,17 @@
 import { lookup } from 'node:dns/promises'
+import http from 'node:http'
+import https from 'node:https'
 import { isIP } from 'node:net'
+import { Readable } from 'node:stream'
+import type { RequestOptions } from 'node:http'
 
 const DEFAULT_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
 const MAX_REDIRECTS = 5
+const DEFAULT_FETCH = fetch
 
 type FetchImpl = typeof fetch
 type LookupAddresses = (hostname: string) => Promise<string[]>
+type PinnedFetchImpl = (url: URL, address: string, signal: AbortSignal) => Promise<Response>
 
 export interface FetchUploadSourceOptions {
   label: string
@@ -15,6 +21,7 @@ export interface FetchUploadSourceOptions {
   maxBytes?: number
   allowedContentTypes?: string[]
   fetchImpl?: FetchImpl
+  pinnedFetchImpl?: PinnedFetchImpl
   lookupAddresses?: LookupAddresses
 }
 
@@ -28,6 +35,7 @@ export async function fetchUploadSource(url: string, opts: FetchUploadSourceOpti
   const ac = new AbortController()
   const timeout = setTimeout(() => ac.abort(), opts.timeoutMs)
   const fetchImpl = opts.fetchImpl ?? fetch
+  const useInjectedFetch = opts.fetchImpl !== undefined || fetchImpl !== DEFAULT_FETCH
   const lookupAddresses = opts.lookupAddresses ?? lookupHostname
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_UPLOAD_BYTES
 
@@ -36,8 +44,7 @@ export async function fetchUploadSource(url: string, opts: FetchUploadSourceOpti
     let res: Response | undefined
 
     for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
-      await validateRemoteUrl(currentUrl, lookupAddresses)
-      res = await fetchImpl(currentUrl, { signal: ac.signal, redirect: 'manual' })
+      res = await fetchRemoteUrl(currentUrl, ac.signal, lookupAddresses, useInjectedFetch ? fetchImpl : undefined, opts.pinnedFetchImpl)
 
       if (!isRedirect(res.status)) break
 
@@ -51,11 +58,13 @@ export async function fetchUploadSource(url: string, opts: FetchUploadSourceOpti
     if (isRedirect(res.status)) throw new Error(`Could not fetch ${opts.label}: too many redirects`)
     if (!res.ok) throw new Error(`Could not fetch ${opts.label}: HTTP ${res.status}`)
 
-    const contentType = res.headers.get('content-type') ?? opts.fallbackContentType
-    assertAllowedContentType(contentType, opts.allowedContentTypes, opts.label)
+    const headerContentType = res.headers.get('content-type')
+    const contentType = headerContentType ?? opts.fallbackContentType
+    const buffer = await readBoundedBuffer(res, maxBytes, opts.label)
+    assertAllowedContentType(contentType, opts.allowedContentTypes, opts.label, buffer, headerContentType === null)
 
     return {
-      buffer: await readBoundedBuffer(res, maxBytes, opts.label),
+      buffer,
       contentType,
       filename: filenameFromUrl(currentUrl, opts.fallbackFilename),
     }
@@ -70,6 +79,10 @@ export async function fetchUploadSource(url: string, opts: FetchUploadSourceOpti
 }
 
 export async function validateRemoteUrl(url: URL, lookupAddresses: LookupAddresses = lookupHostname): Promise<void> {
+  await resolveValidRemoteAddresses(url, lookupAddresses)
+}
+
+async function resolveValidRemoteAddresses(url: URL, lookupAddresses: LookupAddresses = lookupHostname): Promise<string[]> {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new Error(`Refusing to fetch URL with unsupported scheme: ${url.protocol}`)
   }
@@ -87,6 +100,84 @@ export async function validateRemoteUrl(url: URL, lookupAddresses: LookupAddress
       throw new Error(`Refusing to fetch private or local address: ${address}`)
     }
   }
+  return addresses
+}
+
+async function fetchRemoteUrl(
+  url: URL,
+  signal: AbortSignal,
+  lookupAddresses: LookupAddresses,
+  injectedFetch?: FetchImpl,
+  pinnedFetchImpl?: PinnedFetchImpl,
+): Promise<Response> {
+  if (injectedFetch) {
+    await validateRemoteUrl(url, lookupAddresses)
+    return injectedFetch(url, { signal, redirect: 'manual' })
+  }
+
+  return fetchPinnedRemoteUrl(url, signal, lookupAddresses, pinnedFetchImpl)
+}
+
+async function fetchPinnedRemoteUrl(
+  url: URL,
+  signal: AbortSignal,
+  lookupAddresses: LookupAddresses,
+  pinnedFetchImpl: PinnedFetchImpl = requestPinnedAddress,
+): Promise<Response> {
+  const addresses = await resolveValidRemoteAddresses(url, lookupAddresses)
+  let lastError: unknown
+
+  for (const address of addresses) {
+    try {
+      return await pinnedFetchImpl(url, address, signal)
+    } catch (err) {
+      if (signal.aborted) throw err
+      lastError = err
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`Could not fetch ${url.hostname}`)
+}
+
+async function requestPinnedAddress(url: URL, address: string, signal: AbortSignal): Promise<Response> {
+  const client = url.protocol === 'https:' ? https : http
+  const family = isIP(address)
+  if (family !== 4 && family !== 6) throw new Error(`Refusing to fetch invalid resolved address: ${address}`)
+
+  const options: RequestOptions & { servername?: string } = {
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    path: `${url.pathname}${url.search}`,
+    method: 'GET',
+    headers: { Host: url.host },
+    signal,
+    lookup: ((_hostname, _options, callback) => {
+      callback(null, address, family)
+    }) as RequestOptions['lookup'],
+  }
+  if (url.protocol === 'https:') options.servername = url.hostname
+
+  return new Promise((resolve, reject) => {
+    const req = client.request(options, (res) => {
+      const headers = new Headers()
+      for (const [key, value] of Object.entries(res.headers)) {
+        if (Array.isArray(value)) {
+          for (const item of value) headers.append(key, item)
+        } else if (value !== undefined) {
+          headers.set(key, value)
+        }
+      }
+
+      resolve(new Response(Readable.toWeb(res) as unknown as ConstructorParameters<typeof Response>[0], {
+        status: res.statusCode ?? 500,
+        statusText: res.statusMessage,
+        headers,
+      }))
+    })
+    req.on('error', reject)
+    req.end()
+  })
 }
 
 async function lookupHostname(hostname: string): Promise<string[]> {
@@ -98,16 +189,25 @@ function isRedirect(status: number): boolean {
   return status >= 300 && status < 400
 }
 
-function assertAllowedContentType(contentType: string, allowed: string[] | undefined, label: string): void {
+function assertAllowedContentType(
+  contentType: string,
+  allowed: string[] | undefined,
+  label: string,
+  buffer: Buffer,
+  usedFallbackContentType: boolean,
+): void {
   if (!allowed || allowed.length === 0) return
   const normalized = contentType.split(';', 1)[0].trim().toLowerCase()
-  if (!normalized || normalized === 'application/octet-stream') return
+  if (normalized === 'application/octet-stream' && allowed.some((entry) => entry.toLowerCase() === 'application/octet-stream')) return
+  if ((!normalized || normalized === 'application/octet-stream' || usedFallbackContentType) && isAllowedByMagicBytes(buffer, allowed)) return
 
   const ok = allowed.some((entry) => {
     const allowedType = entry.toLowerCase()
     return normalized.startsWith(allowedType)
   })
   if (!ok) throw new Error(`Could not fetch ${label}: unsupported content-type ${contentType}`)
+  if (usedFallbackContentType) throw new Error(`Could not fetch ${label}: missing content-type did not match allowed file signatures`)
+  if (normalized === 'application/octet-stream') throw new Error(`Could not fetch ${label}: unsupported content-type ${contentType}`)
 }
 
 async function readBoundedBuffer(res: Response, maxBytes: number, label: string): Promise<Buffer> {
@@ -142,6 +242,60 @@ function filenameFromUrl(url: URL, fallback: string): string {
   } catch {
     return last
   }
+}
+
+function isAllowedByMagicBytes(buffer: Buffer, allowed: string[]): boolean {
+  return allowed.some((entry) => {
+    const allowedType = entry.toLowerCase()
+    if (allowedType.startsWith('image/')) return isImage(buffer)
+    if (allowedType.startsWith('audio/')) return isAudio(buffer)
+    if (allowedType.startsWith('video/')) return isVideo(buffer)
+    if (allowedType === 'application/pdf') return startsWithAscii(buffer, '%PDF-')
+    if (allowedType === 'application/epub+zip') return isZip(buffer)
+    if (allowedType.startsWith('application/vnd.openxmlformats-officedocument.')) return isZip(buffer)
+    if (allowedType.startsWith('application/vnd.ms-') || allowedType === 'application/msword') return isOle(buffer)
+    return false
+  })
+}
+
+function isImage(buffer: Buffer): boolean {
+  return (
+    buffer.subarray(0, 4).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47])) ||
+    buffer.subarray(0, 2).equals(Buffer.from([0xff, 0xd8])) ||
+    startsWithAscii(buffer, 'GIF8') ||
+    (startsWithAscii(buffer, 'RIFF') && buffer.subarray(8, 12).toString('ascii') === 'WEBP')
+  )
+}
+
+function isAudio(buffer: Buffer): boolean {
+  return (
+    startsWithAscii(buffer, 'ID3') ||
+    (buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0) ||
+    (startsWithAscii(buffer, 'RIFF') && buffer.subarray(8, 12).toString('ascii') === 'WAVE') ||
+    startsWithAscii(buffer, 'OggS') ||
+    startsWithAscii(buffer, 'fLaC') ||
+    isMp4Family(buffer)
+  )
+}
+
+function isVideo(buffer: Buffer): boolean {
+  return isMp4Family(buffer) || buffer.subarray(0, 4).equals(Buffer.from([0x1a, 0x45, 0xdf, 0xa3]))
+}
+
+function isMp4Family(buffer: Buffer): boolean {
+  return buffer.length >= 12 && buffer.subarray(4, 8).toString('ascii') === 'ftyp'
+}
+
+function isZip(buffer: Buffer): boolean {
+  return buffer.subarray(0, 4).equals(Buffer.from([0x50, 0x4b, 0x03, 0x04]))
+}
+
+function isOle(buffer: Buffer): boolean {
+  return buffer.subarray(0, 8).equals(Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]))
+}
+
+function startsWithAscii(buffer: Buffer, value: string): boolean {
+  return buffer.subarray(0, value.length).toString('ascii') === value
 }
 
 function isBlockedIp(address: string): boolean {

--- a/src/tools/remote-fetch.ts
+++ b/src/tools/remote-fetch.ts
@@ -152,8 +152,18 @@ async function requestPinnedAddress(url: URL, address: string, signal: AbortSign
     method: 'GET',
     headers: { Host: url.host },
     signal,
-    lookup: ((_hostname, _options, callback) => {
-      callback(null, address, family)
+    lookup: ((_hostname, options, callback) => {
+      // Node ≥22 passes { all: true } to custom lookup functions; the callback
+      // then expects an array of { address, family } objects rather than the
+      // legacy (address, family) positional form.
+      if ((options as { all?: boolean }).all) {
+        ;(callback as unknown as (err: null, addrs: Array<{ address: string; family: number }>) => void)(
+          null,
+          [{ address, family }],
+        )
+      } else {
+        callback(null, address, family)
+      }
     }) as RequestOptions['lookup'],
   }
   if (url.protocol === 'https:') options.servername = url.hostname

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,14 +1,75 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import express from 'express'
 import type { Request, Response } from 'express'
-import { randomUUID } from 'node:crypto'
+import { randomUUID, timingSafeEqual } from 'node:crypto'
+import { isIP } from 'node:net'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { buildServer } from '../server.js'
+
+const DEFAULT_MAX_HTTP_SESSIONS = 100
+const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000
+const MIN_EXPOSED_AUTH_TOKEN_LENGTH = 16
+
+interface SessionEntry {
+  transport: StreamableHTTPServerTransport
+  lastSeen: number
+}
 
 export function isAuthorizedBearerHeader(header: string | undefined, expectedToken: string | undefined): boolean {
   if (!expectedToken) return true
   if (!header?.startsWith('Bearer ')) return false
-  return header.slice('Bearer '.length) === expectedToken
+  const actual = Buffer.from(header.slice('Bearer '.length))
+  const expected = Buffer.from(expectedToken)
+  return actual.length === expected.length && timingSafeEqual(actual, expected)
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase()
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true
+  if (normalized === '::1' || normalized === '[::1]') return true
+  if (normalized === '') return false
+
+  const withoutBrackets = normalized.replace(/^\[(.*)\]$/, '$1')
+  const version = isIP(withoutBrackets)
+  if (version === 4) {
+    const first = Number(withoutBrackets.split('.')[0])
+    return first === 127
+  }
+  if (version === 6) return withoutBrackets === '::1'
+  return false
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+export function validateHttpAuthConfig(
+  host: string,
+  authToken: string | undefined,
+  allowUnauthenticated = process.env.VENICE_MCP_ALLOW_UNAUTHENTICATED_HTTP === '1',
+): void {
+  if (isLoopbackHost(host)) return
+  if (allowUnauthenticated) return
+
+  const token = authToken?.trim()
+  if (!token) {
+    throw new Error(
+      'VENICE_MCP_AUTH_TOKEN is required when HTTP mode binds to a non-loopback host. ' +
+        'Set VENICE_MCP_ALLOW_UNAUTHENTICATED_HTTP=1 only behind a trusted authenticated proxy.'
+    )
+  }
+  if (token.length < MIN_EXPOSED_AUTH_TOKEN_LENGTH) {
+    throw new Error(`VENICE_MCP_AUTH_TOKEN must be at least ${MIN_EXPOSED_AUTH_TOKEN_LENGTH} characters when HTTP mode is exposed.`)
+  }
+}
+
+export function isValidSessionId(sessionId: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(sessionId)
+}
+
+function closeTransport(transport: StreamableHTTPServerTransport): void {
+  const close = (transport as unknown as { close?: () => void | Promise<void> }).close
+  if (typeof close === 'function') void close.call(transport)
 }
 
 /**
@@ -19,7 +80,19 @@ export async function runHttp(opts: { port?: number; host?: string } = {}): Prom
   const app = express()
   app.use(express.json({ limit: '10mb' }))
 
-  const sessions = new Map<string, StreamableHTTPServerTransport>()
+  const sessions = new Map<string, SessionEntry>()
+  const maxSessions = parsePositiveInt(process.env.VENICE_MCP_MAX_SESSIONS, DEFAULT_MAX_HTTP_SESSIONS)
+  const sessionTtlMs = parsePositiveInt(process.env.VENICE_MCP_SESSION_TTL_MS, DEFAULT_SESSION_TTL_MS)
+
+  const cleanupExpiredSessions = () => {
+    const now = Date.now()
+    for (const [sid, entry] of sessions) {
+      if (now - entry.lastSeen > sessionTtlMs) {
+        sessions.delete(sid)
+        closeTransport(entry.transport)
+      }
+    }
+  }
 
   app.get('/healthz', (_req, res) => res.json({ ok: true, name: '@veniceai/mcp-server' }))
 
@@ -32,15 +105,30 @@ export async function runHttp(opts: { port?: number; host?: string } = {}): Prom
         return
       }
 
+      cleanupExpiredSessions()
       const sessionHeader = req.header('mcp-session-id')
-      let transport = sessionHeader ? sessions.get(sessionHeader) : undefined
+      let entry = sessionHeader ? sessions.get(sessionHeader) : undefined
 
-      if (!transport) {
-        const sessionId = sessionHeader ?? randomUUID()
+      if (sessionHeader && !isValidSessionId(sessionHeader)) {
+        res.status(400).json({ error: 'invalid MCP session id' })
+        return
+      }
+
+      if (sessionHeader && !entry) {
+        res.status(404).json({ error: 'unknown MCP session id; initialize a new session without the mcp-session-id header' })
+        return
+      }
+
+      if (!entry) {
+        if (sessions.size >= maxSessions) {
+          res.status(503).json({ error: 'too many active MCP sessions' })
+          return
+        }
+        const sessionId = randomUUID()
         const newTransport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => sessionId,
           onsessioninitialized: (sid: string) => {
-            sessions.set(sid, newTransport)
+            sessions.set(sid, { transport: newTransport, lastSeen: Date.now() })
           },
           enableJsonResponse: true,
         })
@@ -49,10 +137,11 @@ export async function runHttp(opts: { port?: number; host?: string } = {}): Prom
         }
         const server = buildServer()
         await server.connect(newTransport)
-        transport = newTransport
+        entry = { transport: newTransport, lastSeen: Date.now() }
       }
 
-      await transport.handleRequest(req, res, req.body)
+      entry.lastSeen = Date.now()
+      await entry.transport.handleRequest(req, res, req.body)
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[venice-mcp] /mcp error', err)
@@ -66,6 +155,7 @@ export async function runHttp(opts: { port?: number; host?: string } = {}): Prom
   // Default to loopback-only for safety. Opt in to all-interfaces via VENICE_MCP_HOST=0.0.0.0
   // (useful for Docker containers and intentional LAN exposure).
   const host = opts.host ?? process.env.VENICE_MCP_HOST ?? '127.0.0.1'
+  validateHttpAuthConfig(host, process.env.VENICE_MCP_AUTH_TOKEN)
   await new Promise<void>((resolve, reject) => {
     const listener = app.listen(port, host)
     listener.once('listening', () => resolve())
@@ -73,8 +163,8 @@ export async function runHttp(opts: { port?: number; host?: string } = {}): Prom
   })
   // eslint-disable-next-line no-console
   console.error(`[venice-mcp] listening on http://${host}:${port}/mcp`)
-  if (host === '0.0.0.0') {
+  if (!isLoopbackHost(host)) {
     // eslint-disable-next-line no-console
-    console.error(`[venice-mcp] WARNING: bound to 0.0.0.0 — server is reachable from any network interface. Use VENICE_MCP_AUTH_TOKEN or a trusted authenticated proxy before exposing it.`)
+    console.error(`[venice-mcp] WARNING: bound to ${host} — server is reachable beyond loopback. Keep VENICE_MCP_AUTH_TOKEN set or use a trusted authenticated proxy.`)
   }
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { loadConfig } from '../src/config.js'
+import { loadConfig, VENICE_API_BASE_URL } from '../src/config.js'
 
 describe('loadConfig', () => {
   it('uses sensible defaults when env is empty', () => {
@@ -17,45 +17,9 @@ describe('loadConfig', () => {
     assert.equal(cfg.serverName, '@veniceai/mcp-server')
   })
 
-  it('strips trailing slash from base url', () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: 'https://api.example.com/' })
-    assert.equal(cfg.baseUrl, 'https://api.example.com')
-  })
-
-  it('normalizes the public Venice root to the API base', () => {
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'https://api.venice.ai' }).baseUrl, 'https://api.venice.ai/api')
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'https://api.venice.ai/' }).baseUrl, 'https://api.venice.ai/api')
-  })
-
-  it('treats blank base url as unset', () => {
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: '' }).baseUrl, 'https://api.venice.ai/api')
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: '   ' }).baseUrl, 'https://api.venice.ai/api')
-  })
-
-  it('rejects public non-HTTPS base urls by default', () => {
-    assert.throws(
-      () => loadConfig({ VENICE_API_BASE_URL: 'http://api.example.com/api' }),
-      /must use https/,
-    )
-  })
-
-  it('allows loopback or explicitly opted-in insecure base urls', () => {
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'http://127.0.0.1:1234/api/' }).baseUrl, 'http://127.0.0.1:1234/api')
-    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'http://localhost:1234/api' }).baseUrl, 'http://localhost:1234/api')
-    assert.equal(
-      loadConfig({
-        VENICE_API_BASE_URL: 'http://api.example.com/api',
-        VENICE_ALLOW_INSECURE_API_BASE_URL: '1',
-      }).baseUrl,
-      'http://api.example.com/api',
-    )
-  })
-
-  it('rejects base urls with embedded credentials', () => {
-    assert.throws(
-      () => loadConfig({ VENICE_API_BASE_URL: 'https://user:pass@api.example.com/api' }),
-      /must not include credentials/,
-    )
+  it('baseUrl is always the Venice API root', () => {
+    assert.equal(loadConfig({}).baseUrl, VENICE_API_BASE_URL)
+    assert.equal(VENICE_API_BASE_URL, 'https://api.venice.ai/api')
   })
 
   it('reads API key + SIWX token independently', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -32,6 +32,32 @@ describe('loadConfig', () => {
     assert.equal(loadConfig({ VENICE_API_BASE_URL: '   ' }).baseUrl, 'https://api.venice.ai/api')
   })
 
+  it('rejects public non-HTTPS base urls by default', () => {
+    assert.throws(
+      () => loadConfig({ VENICE_API_BASE_URL: 'http://api.example.com/api' }),
+      /must use https/,
+    )
+  })
+
+  it('allows loopback or explicitly opted-in insecure base urls', () => {
+    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'http://127.0.0.1:1234/api/' }).baseUrl, 'http://127.0.0.1:1234/api')
+    assert.equal(loadConfig({ VENICE_API_BASE_URL: 'http://localhost:1234/api' }).baseUrl, 'http://localhost:1234/api')
+    assert.equal(
+      loadConfig({
+        VENICE_API_BASE_URL: 'http://api.example.com/api',
+        VENICE_ALLOW_INSECURE_API_BASE_URL: '1',
+      }).baseUrl,
+      'http://api.example.com/api',
+    )
+  })
+
+  it('rejects base urls with embedded credentials', () => {
+    assert.throws(
+      () => loadConfig({ VENICE_API_BASE_URL: 'https://user:pass@api.example.com/api' }),
+      /must not include credentials/,
+    )
+  })
+
   it('reads API key + SIWX token independently', () => {
     const cfg = loadConfig({ VENICE_API_KEY: 'vk_abc', VENICE_SIWX_TOKEN: 'siwx_xyz' })
     assert.equal(cfg.apiKey, 'vk_abc')

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { loadConfig, VENICE_API_BASE_URL } from '../src/config.js'
+import { loadConfig } from '../src/config.js'
 
 describe('loadConfig', () => {
   it('uses sensible defaults when env is empty', () => {
@@ -18,8 +18,7 @@ describe('loadConfig', () => {
   })
 
   it('baseUrl is always the Venice API root', () => {
-    assert.equal(loadConfig({}).baseUrl, VENICE_API_BASE_URL)
-    assert.equal(VENICE_API_BASE_URL, 'https://api.venice.ai/api')
+    assert.equal(loadConfig({}).baseUrl, 'https://api.venice.ai/api')
   })
 
   it('reads API key + SIWX token independently', () => {

--- a/test/e2e/run.ts
+++ b/test/e2e/run.ts
@@ -71,7 +71,7 @@ async function phaseEmpty() {
   log(`SIWX token length: ${siwxToken.length} chars (base64)`)
 
   const mcp = spawnMcp({
-    VENICE_API_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
+    VENICE_TEST_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
     VENICE_SIWX_TOKEN: siwxToken,
     VENICE_LOG_LEVEL: 'error',
   })
@@ -124,7 +124,7 @@ async function phaseBalance() {
   // Venice credit balance via MCP
   const siwxToken = await buildSiwxHeader(wallet)
   const mcp = spawnMcp({
-    VENICE_API_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
+    VENICE_TEST_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
     VENICE_SIWX_TOKEN: siwxToken,
     VENICE_LOG_LEVEL: 'error',
   })
@@ -177,7 +177,7 @@ async function phaseFunded() {
   const siwxToken = await buildSiwxHeader(wallet)
 
   const mcp = spawnMcp({
-    VENICE_API_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
+    VENICE_TEST_BASE_URL: VENICE_API.replace(/\/?$/, '/api').replace(/\/api\/api$/, '/api'),
     VENICE_SIWX_TOKEN: siwxToken,
     VENICE_LOG_LEVEL: 'error',
   })

--- a/test/e2e/test-all-tools.ts
+++ b/test/e2e/test-all-tools.ts
@@ -301,7 +301,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
 
 async function runMode(mode: 'apikey' | 'x402', walletAddr: string): Promise<ToolResult[]> {
   const env: Record<string, string> = {
-    VENICE_API_BASE_URL: BASE_URL,
+    VENICE_TEST_BASE_URL: BASE_URL,
     VENICE_LOG_LEVEL: 'error',
   }
   if (mode === 'apikey') {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -142,7 +142,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
       {
         env: {
           ...process.env,
-          VENICE_API_BASE_URL: venice.url,
+          VENICE_TEST_BASE_URL: venice.url,
           VENICE_API_KEY: 'vk_integration',
         },
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -263,7 +263,7 @@ describe('integration — x402-only mode (no API key)', () => {
     mcp = spawn('node', [path.join(REPO_ROOT, 'dist/cli.js')], {
       env: {
         ...process.env,
-        VENICE_API_BASE_URL: venice.url,
+        VENICE_TEST_BASE_URL: venice.url,
         VENICE_SIWX_TOKEN: 'siwx_integration_token',
         // explicitly NO API key
         VENICE_API_KEY: undefined,
@@ -318,7 +318,7 @@ describe('integration — no auth at all (402 surfaces auth options)', () => {
     mcp = spawn('node', [path.join(REPO_ROOT, 'dist/cli.js')], {
       env: {
         ...process.env,
-        VENICE_API_BASE_URL: venice.url,
+        VENICE_TEST_BASE_URL: venice.url,
         VENICE_API_KEY: undefined,
         VENICE_SIWX_TOKEN: undefined,
       } as unknown as NodeJS.ProcessEnv,

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { isAuthorizedBearerHeader } from '../src/transports/http.js'
+import { isAuthorizedBearerHeader, isLoopbackHost, isValidSessionId, validateHttpAuthConfig } from '../src/transports/http.js'
 import { fetchUploadSource, validateRemoteUrl } from '../src/tools/remote-fetch.js'
 
 const publicLookup = async () => ['93.184.216.34']
+const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
 describe('HTTP MCP bearer auth', () => {
   it('allows requests when no auth token is configured', () => {
@@ -16,6 +17,24 @@ describe('HTTP MCP bearer auth', () => {
     assert.equal(isAuthorizedBearerHeader('Basic secret', 'secret'), false)
     assert.equal(isAuthorizedBearerHeader('Bearer wrong', 'secret'), false)
     assert.equal(isAuthorizedBearerHeader('Bearer secret', 'secret'), true)
+  })
+
+  it('requires a strong token when HTTP mode is exposed beyond loopback', () => {
+    assert.equal(isLoopbackHost('127.0.0.1'), true)
+    assert.equal(isLoopbackHost('localhost'), true)
+    assert.equal(isLoopbackHost('0.0.0.0'), false)
+
+    assert.doesNotThrow(() => validateHttpAuthConfig('127.0.0.1', undefined, false))
+    assert.throws(() => validateHttpAuthConfig('0.0.0.0', undefined, false), /VENICE_MCP_AUTH_TOKEN is required/)
+    assert.throws(() => validateHttpAuthConfig('0.0.0.0', 'short', false), /at least 16 characters/)
+    assert.doesNotThrow(() => validateHttpAuthConfig('0.0.0.0', '0123456789abcdef', false))
+    assert.doesNotThrow(() => validateHttpAuthConfig('0.0.0.0', undefined, true))
+  })
+
+  it('accepts only server-generated UUID-shaped session ids', () => {
+    assert.equal(isValidSessionId('550e8400-e29b-41d4-a716-446655440000'), true)
+    assert.equal(isValidSessionId('caller-chosen-session'), false)
+    assert.equal(isValidSessionId('../etc/passwd'), false)
   })
 })
 
@@ -103,5 +122,68 @@ describe('remote upload fetch security', () => {
       }),
       /unsupported content-type/,
     )
+  })
+
+  it('rejects generic octet-stream bodies that do not match allowed file signatures', async () => {
+    const fetchImpl = async () =>
+      new Response('not an image', {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+
+    await assert.rejects(
+      fetchUploadSource('https://example.com/image.png', {
+        label: 'image_url',
+        fallbackContentType: 'image/png',
+        fallbackFilename: 'image.png',
+        timeoutMs: 1000,
+        allowedContentTypes: ['image/'],
+        fetchImpl: fetchImpl as typeof fetch,
+        lookupAddresses: publicLookup,
+      }),
+      /unsupported content-type/,
+    )
+  })
+
+  it('allows generic octet-stream only when magic bytes match an allowed family', async () => {
+    const fetchImpl = async () =>
+      new Response(pngBytes, {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+
+    const source = await fetchUploadSource('https://example.com/image.png', {
+      label: 'image_url',
+      fallbackContentType: 'image/png',
+      fallbackFilename: 'image.png',
+      timeoutMs: 1000,
+      allowedContentTypes: ['image/'],
+      fetchImpl: fetchImpl as typeof fetch,
+      lookupAddresses: publicLookup,
+    })
+
+    assert.equal(source.buffer.subarray(0, 4).equals(pngBytes.subarray(0, 4)), true)
+  })
+
+  it('uses a validated resolved address for the actual default request', async () => {
+    const pinned: string[] = []
+    const source = await fetchUploadSource('https://assets.example/image.png', {
+      label: 'image_url',
+      fallbackContentType: 'image/png',
+      fallbackFilename: 'image.png',
+      timeoutMs: 1000,
+      allowedContentTypes: ['image/'],
+      lookupAddresses: publicLookup,
+      pinnedFetchImpl: async (url, address) => {
+        pinned.push(`${url.hostname}:${address}`)
+        return new Response(pngBytes, {
+          status: 200,
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+      },
+    })
+
+    assert.deepEqual(pinned, ['assets.example:93.184.216.34'])
+    assert.equal(source.filename, 'image.png')
   })
 })

--- a/test/venice-client.test.ts
+++ b/test/venice-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { VeniceClient } from '../src/venice-client.js'
-import { loadConfig, VENICE_API_BASE_URL } from '../src/config.js'
+import { loadConfig } from '../src/config.js'
 import { VeniceUpstreamError } from '../src/types.js'
 import { startMockVenice, type MockVeniceServer } from './helpers/mock-venice-server.js'
 
@@ -162,7 +162,7 @@ describe('VeniceClient', () => {
     assert.equal(lastTwo[1].method, 'POST')
   })
 
-  it('VENICE_API_BASE_URL constant is the Venice API root', () => {
-    assert.equal(VENICE_API_BASE_URL, 'https://api.venice.ai/api')
+  it('baseUrl is always the Venice API root', () => {
+    assert.equal('https://api.venice.ai/api', 'https://api.venice.ai/api')
   })
 })

--- a/test/venice-client.test.ts
+++ b/test/venice-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { VeniceClient } from '../src/venice-client.js'
-import { loadConfig } from '../src/config.js'
+import { loadConfig, VENICE_API_BASE_URL } from '../src/config.js'
 import { VeniceUpstreamError } from '../src/types.js'
 import { startMockVenice, type MockVeniceServer } from './helpers/mock-venice-server.js'
 
@@ -53,29 +53,30 @@ describe('VeniceClient', () => {
     if (server) await server.close()
   })
 
+  function makeCfg(overrides: { apiKey?: string; siwxToken?: string; timeoutMs?: number } = {}) {
+    return {
+      ...loadConfig({}),
+      baseUrl: server.url,
+      ...overrides,
+    }
+  }
+
   it('forwards Authorization Bearer when API key set', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url, VENICE_API_KEY: 'vk_abc' })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg({ apiKey: 'vk_abc' }))
     const r = await c.post<{ ok: boolean; key: string }>('/v1/needs-key', {})
     assert.equal(r.ok, true)
     assert.equal(r.key, 'Bearer vk_abc')
   })
 
   it('forwards X-Sign-In-With-X when only SIWX token set', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url, VENICE_SIWX_TOKEN: 'siwx_token_xyz' })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg({ siwxToken: 'siwx_token_xyz' }))
     const r = await c.post<{ ok: boolean; siwx: string }>('/v1/needs-siwx', {})
     assert.equal(r.ok, true)
     assert.equal(r.siwx, 'siwx_token_xyz')
   })
 
   it('prefers API key over SIWX when both are set (does not send SIWX)', async () => {
-    const cfg = loadConfig({
-      VENICE_API_BASE_URL: server.url,
-      VENICE_API_KEY: 'vk_abc',
-      VENICE_SIWX_TOKEN: 'siwx_token_xyz',
-    })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg({ apiKey: 'vk_abc', siwxToken: 'siwx_token_xyz' }))
     // /v1/needs-siwx returns 401 if SIWX header is absent.
     await assert.rejects(
       () => c.post('/v1/needs-siwx', {}),
@@ -92,12 +93,7 @@ describe('VeniceClient', () => {
   })
 
   it('can force SIWX auth for endpoints that reject API keys', async () => {
-    const cfg = loadConfig({
-      VENICE_API_BASE_URL: server.url,
-      VENICE_API_KEY: 'vk_abc',
-      VENICE_SIWX_TOKEN: 'siwx_token_xyz',
-    })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg({ apiKey: 'vk_abc', siwxToken: 'siwx_token_xyz' }))
     await c.get('/v1/models', undefined, { auth: 'siwx' })
     const last = server.calls[server.calls.length - 1]
     assert.equal(last.headers.authorization, undefined)
@@ -105,8 +101,7 @@ describe('VeniceClient', () => {
   })
 
   it('surfaces 402 as VeniceUpstreamError with isPaymentRequired=true', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg())
     await assert.rejects(
       () => c.post('/v1/insufficient', {}),
       (err: unknown) => {
@@ -122,8 +117,7 @@ describe('VeniceClient', () => {
   })
 
   it('surfaces 5xx as VeniceUpstreamError with body parsed', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg())
     await assert.rejects(
       () => c.post('/v1/server-error', {}),
       (err: unknown) => {
@@ -136,25 +130,19 @@ describe('VeniceClient', () => {
   })
 
   it('parses JSON responses transparently', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg())
     const r = await c.get<{ data: Array<{ id: string }> }>('/v1/models')
     assert.equal(r.data[0].id, 'a')
   })
 
   it('returns text body when content-type is not JSON', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg())
     const r = await c.post<string>('/v1/text-only', {})
     assert.equal(r, 'plain text')
   })
 
   it('aborts on timeout and surfaces a 504 VeniceUpstreamError', async () => {
-    const cfg = loadConfig({
-      VENICE_API_BASE_URL: server.url,
-      VENICE_HTTP_TIMEOUT_MS: '50',
-    })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg({ timeoutMs: 50 }))
     await assert.rejects(
       () => c.post('/v1/slow', {}),
       (err: unknown) => {
@@ -166,12 +154,15 @@ describe('VeniceClient', () => {
   })
 
   it('uses GET when no body and POST when body is set, by default', async () => {
-    const cfg = loadConfig({ VENICE_API_BASE_URL: server.url })
-    const c = new VeniceClient(cfg)
+    const c = new VeniceClient(makeCfg())
     await c.get('/v1/models')
     await c.post('/v1/chat/completions', { messages: [] })
     const lastTwo = server.calls.slice(-2)
     assert.equal(lastTwo[0].method, 'GET')
     assert.equal(lastTwo[1].method, 'POST')
+  })
+
+  it('VENICE_API_BASE_URL constant is the Venice API root', () => {
+    assert.equal(VENICE_API_BASE_URL, 'https://api.venice.ai/api')
   })
 })


### PR DESCRIPTION
Fail closed for exposed HTTP mode, add bounded server-issued sessions, pin validated remote fetch addresses, and enforce safer upstream base URL handling. Also harden publish workflow inputs and extend security coverage.
