### PR TITLE
ci: force Node 24 for actions to fix npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,7 @@ jobs:
 
     env:
       REGISTRY_URL: https://registry.npmjs.org
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Check out release target


### PR DESCRIPTION
The `actions/setup-node@v4` action itself runs on Node 20 (deprecated) and isn't correctly setting up the PATH, so shell steps still see Node 22 from the runner cache despite `node-version: 24` being set. Adding `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the job env level forces all actions to run on Node 24, fixing the setup-node resolution.