### PR TITLE
ci: upgrade checkout + setup-node to v6 to fix Node 24 resolution

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out release target
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           echo "branch=${target}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           registry-url: ${{ env.REGISTRY_URL }}


### PR DESCRIPTION
The pinned v4 commits of both `actions/checkout` and `actions/setup-node` predate Node 24 support — `setup-node` was silently falling back to the Node 22 runner cache despite `node-version: 24` being set. Upgrading both to v6 (latest stable) fixes this.