### PR TITLE
ci: remove npm install -g step that crashes on runner

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,9 +51,6 @@ jobs:
           node-version: 24
           registry-url: ${{ env.REGISTRY_URL }}
 
-      - name: Use npm with trusted publishing support
-        run: npm install -g npm@latest
-
       - name: Set package version
         id: version
         shell: bash


### PR DESCRIPTION
The `npm install -g npm@latest` step crashes on every runner with `MODULE_NOT_FOUND: promise-retry` regardless of Node version. Node 24 ships with npm 11.x which already supports `--provenance` natively — this step is unnecessary and has been blocking every release attempt.