### PR TITLE
ci: build before test — integration tests need dist/cli.js

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -92,11 +92,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm test
-
       - name: Build package
         run: npm run build
+
+      - name: Run tests
+        run: npm test
 
       - name: Check npm package version
         id: npm_status


### PR DESCRIPTION
The integration tests spawn `dist/cli.js` and timeout with `RPC timeout: initialize` because the build step ran after tests. Swapping the order fixes it.