### PR TITLE
ci: drop --provenance for alpha release (private repo)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -122,7 +122,8 @@ jobs:
         if: steps.npm_status.outputs.exists != 'true'
         env:
           PUBLISH_TAG: ${{ steps.version.outputs.publish_tag }}
-        run: npm publish --provenance --access public --tag "$PUBLISH_TAG"
+        # TODO: add --provenance back once the repo is made public (provenance requires a public repo)
+        run: npm publish --access public --tag "$PUBLISH_TAG"
 
       - name: Commit version bump
         shell: bash


### PR DESCRIPTION
npm provenance requires a public repository. Dropping it for the alpha; TODO to restore when the repo is made public before the final release.