### PR TITLE
feat: expand venice_video_generate inputs + bump to 0.1.2-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -67,7 +67,7 @@ npx -y @smithery/cli install venice
 
 | Tool | Description |
 |---|---|
-| `venice_video_generate` | Queue a video generation. Supports Sora 2, Veo 3.1, Kling, Wan, LTX 2, Seedance, Runway Gen-4, and others. |
+| `venice_video_generate` | Queue a video generation. Supports Sora 2, Veo 3.1, Kling, Wan, LTX 2, Seedance (incl. r2v video-to-video), Runway Gen-4, and others. Accepts image, video, audio, and reference image inputs depending on model. |
 | `venice_video_status` | Check status of a queued video job. Returns `PROCESSING` or `COMPLETED`. |
 | `venice_video_complete` | Mark a completed video as downloaded; deletes server-side media. |
 | `venice_video_transcriptions` | Transcribe a YouTube video URL. |
@@ -171,7 +171,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -381,7 +381,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@veniceai/mcp-server",
-      "version": "0.1.1-alpha",
+      "version": "0.1.2-alpha",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2-alpha",
   "description": "Model Context Protocol server for Venice.ai — uncensored, private, crypto-native AI inference for Claude, ChatGPT, Cursor and any MCP host. Community-maintained. Provided as-is, with no warranty or SLA from Venice AI. Use at your own risk.",
   "license": "MIT",
   "author": "Venice AI",

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     timeoutMs: parseTimeoutMs(env.VENICE_HTTP_TIMEOUT_MS),
     enableNsfw: env.VENICE_DISABLE_NSFW !== '1',
     serverName: '@veniceai/mcp-server',
-    serverVersion: '0.1.0',
+    serverVersion: '0.1.2-alpha',
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -392,6 +392,13 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         video_url: z.string().url().optional().describe('For video-to-video models (e.g. seedance-2-0-r2v): input video. URL or data URL. Supported: MP4, MOV, WebM.'),
         audio_url: z.string().url().optional().describe('For models that support audio input: background music. URL or data URL. Supported: WAV, MP3. Max 30s, 15MB.'),
         reference_image_urls: z.array(z.string().url()).max(9).optional().describe('For models with reference image support: up to 9 images for character/style consistency. Each a URL or data URL.'),
+        reference_video_urls: z.array(z.string().url()).max(3).optional().describe('For Seedance 2.0 R2V and similar: up to 3 reference video clips to inherit subject motion, camera movement, and style. Per-clip 2–15s, MP4/MOV, ≤50MB; aggregate ≤15s. Each a URL or data URL.'),
+        elements: z.array(z.object({
+          frontal_image_url: z.string().url().optional(),
+          reference_image_urls: z.array(z.string().url()).max(3).optional(),
+          video_url: z.string().url().optional(),
+        })).max(4).optional().describe('For Kling O3 R2V and similar: up to 4 character/object elements. Reference in prompt as @Element1, @Element2, etc.'),
+        scene_image_urls: z.array(z.string().url()).max(4).optional().describe('For models with advanced element support: up to 4 scene reference images. Reference in prompt as @Image1, @Image2, etc.'),
         negative_prompt: z.string().max(4096).optional().describe('Negative prompt (what to avoid). Supported by Seedance and other models.'),
         resolution: z.string().optional().describe('Output resolution, e.g. "720p", "1080p", "4k". Model-specific; see model card.'),
         upscale_factor: z.number().int().optional().describe('For upscale models only: 1 = quality enhance, 2 = double resolution, 4 = quadruple.'),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -393,6 +393,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         audio_url: z.string().url().optional().describe('For models that support audio input: background music. URL or data URL. Supported: WAV, MP3. Max 30s, 15MB.'),
         reference_image_urls: z.array(z.string().url()).max(9).optional().describe('For models with reference image support: up to 9 images for character/style consistency. Each a URL or data URL.'),
         reference_video_urls: z.array(z.string().url()).max(3).optional().describe('For Seedance 2.0 R2V and similar: up to 3 reference video clips to inherit subject motion, camera movement, and style. Per-clip 2–15s, MP4/MOV, ≤50MB; aggregate ≤15s. Each a URL or data URL.'),
+        reference_audio_urls: z.array(z.string().url()).max(3).optional().describe('For Seedance 2.0 R2V and similar: up to 3 reference audio clips for vocal timbre, narration, or sound effects. Per-clip 2–15s, WAV/MP3; aggregate ≤15s. Must be paired with at least one reference image or video. Each a URL or data URL.'),
         elements: z.array(z.object({
           frontal_image_url: z.string().url().optional(),
           reference_image_urls: z.array(z.string().url()).max(3).optional(),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -380,14 +380,22 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
     {
       name: 'venice_video_generate',
       title: 'Venice Video Queue',
-      description: `Queue a video generation. Supports Sora 2, Veo 3.1, Kling, Wan, LTX 2, Seedance, Runway Gen-4, and others. Pick a specific id like "veo3.1-fast-text-to-video", "veo3.1-fast-image-to-video", "kling-2.6-pro-text-to-video", "wan-2.6-text-to-video" etc.${nsfwNote}${X402_OK} Returns { model, queue_id }; poll with venice_video_status. NOTE: 'duration' is a string enum like '4s' / '6s' / '8s' (model-specific, see model card).`,
+      description: `Queue a video generation. Supports Sora 2, Veo 3.1, Kling, Wan, LTX 2, Seedance, Runway Gen-4, and others. Pick a specific id like "veo3.1-fast-text-to-video", "veo3.1-fast-image-to-video", "kling-2.6-pro-text-to-video", "wan-2.6-text-to-video", "seedance-2-0-r2v" etc.${nsfwNote}${X402_OK} Returns { model, queue_id }; poll with venice_video_status. NOTE: 'duration' is a string enum like '4s' / '6s' / '8s' (model-specific, see model card).`,
       inputSchema: {
-        prompt: z.string().min(1).max(4000),
+        prompt: z.string().min(1).max(4096),
         model: z.string().describe('Required. Full model id, e.g. "veo3.1-fast-text-to-video".'),
         duration: z.string().optional().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s". See GET /v1/models/:id/card.'),
-        aspect_ratio: z.enum(['16:9', '9:16', '1:1']).optional(),
+        aspect_ratio: z.enum(['16:9', '9:16', '1:1', '2:3', '3:2', '3:4', '4:3', '21:9']).optional(),
         seed: z.number().int().optional(),
-        image_url: z.string().url().optional().describe('Required for *-image-to-video models; starting frame URL or data URL.'),
+        image_url: z.string().url().optional().describe('For image-to-video models: starting frame. URL or data URL.'),
+        end_image_url: z.string().url().optional().describe('For models that support end frames or transitions. URL or data URL.'),
+        video_url: z.string().url().optional().describe('For video-to-video models (e.g. seedance-2-0-r2v): input video. URL or data URL. Supported: MP4, MOV, WebM.'),
+        audio_url: z.string().url().optional().describe('For models that support audio input: background music. URL or data URL. Supported: WAV, MP3. Max 30s, 15MB.'),
+        reference_image_urls: z.array(z.string().url()).max(9).optional().describe('For models with reference image support: up to 9 images for character/style consistency. Each a URL or data URL.'),
+        negative_prompt: z.string().max(4096).optional().describe('Negative prompt (what to avoid). Supported by Seedance and other models.'),
+        resolution: z.string().optional().describe('Output resolution, e.g. "720p", "1080p", "4k". Model-specific; see model card.'),
+        upscale_factor: z.number().int().optional().describe('For upscale models only: 1 = quality enhance, 2 = double resolution, 4 = quadruple.'),
+        audio: z.boolean().optional().describe('Enable or disable audio generation for models that support it. Defaults to true.'),
       },
       handler: async (args) => {
         try {


### PR DESCRIPTION
## Summary

Expands the `venice_video_generate` tool to expose all fields supported by the `POST /v1/video/queue` API, and bumps the package to `0.1.2-alpha`.

Synced against the outerface swagger (source of truth).

## New fields

| Field | Description |
|---|---|
| `video_url` | For video-to-video models (e.g. **Seedance 2.0 r2v**). URL or data URL. Supported: MP4, MOV, WebM. |
| `end_image_url` | End frame / transition support. URL or data URL. |
| `audio_url` | Background music input. URL or data URL. WAV/MP3, max 30s/15MB. |
| `reference_image_urls` | Up to 9 reference images for character/style consistency. |
| `reference_video_urls` | Up to 3 reference video clips (Seedance 2.0 R2V) to inherit subject motion, camera movement, and style. Per-clip 2–15s, MP4/MOV, ≤50MB; aggregate ≤15s. |
| `reference_audio_urls` | Up to 3 reference audio clips (Seedance 2.0 R2V) for vocal timbre, narration, or sound effects. Per-clip 2–15s, WAV/MP3; aggregate ≤15s. Must be paired with at least one reference image or video. |
| `negative_prompt` | What to avoid. Supported by Seedance and other models. |
| `resolution` | Output resolution, e.g. `720p`, `1080p`, `4k`. Model-specific. |
| `upscale_factor` | For upscale models: 1 = enhance, 2 = double, 4 = quadruple. |
| `audio` | Enable/disable audio generation where supported. |
| `elements` | Up to 4 character/object definitions for Kling O3 R2V (`@Element1` etc.), each with `frontal_image_url`, `reference_image_urls[]`, `video_url`. |
| `scene_image_urls` | Up to 4 scene reference images for advanced element support (`@Image1` etc.). |

## Other changes

- `aspect_ratio` enum expanded: adds `2:3`, `3:2`, `3:4`, `4:3`, `21:9`
- `prompt` max bumped `4000` → `4096` (matches swagger)
- `seedance-2-0-r2v` added to description as a named example
- README tool description updated; all version refs bumped to `0.1.2-alpha`

## No handler changes needed

The handler already spreads `args` directly into the POST body — all new fields pass through automatically.