### PR TITLE
chore: GA release — v0.2.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -122,8 +122,7 @@ jobs:
         if: steps.npm_status.outputs.exists != 'true'
         env:
           PUBLISH_TAG: ${{ steps.version.outputs.publish_tag }}
-        # TODO: add --provenance back once the repo is made public (provenance requires a public repo)
-        run: npm publish --access public --tag "$PUBLISH_TAG"
+        run: npm publish --access public --tag "$PUBLISH_TAG" --provenance
 
       - name: Commit version bump
         shell: bash

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
+      "args": ["-y", "@veniceai/mcp-server"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -171,7 +171,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
+      "args": ["-y", "@veniceai/mcp-server"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -381,7 +381,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.2-alpha"],
+      "args": ["-y", "@veniceai/mcp-server"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [API key guide](https://docs.venice.ai/guides/getting-started/generating
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }
@@ -171,7 +171,7 @@ Venice supports authenticating with a **SIWE-signed wallet token** (a.k.a. SIWX)
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
       "env": { "VENICE_SIWX_TOKEN": "<base64 SIWE payload>" }
     }
   }
@@ -381,7 +381,7 @@ The most common cause is that `VENICE_API_KEY` isn't being forwarded to the MCP 
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
       "env": { "VENICE_API_KEY": "<your-venice-api-key>" }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -5,13 +5,29 @@
   "description": "Uncensored, private, crypto-native AI inference (LLM, image, video, TTS, ASR, music, characters) by Venice.ai. Pay-per-call via x402, optional API key, no account required. Community-maintained, provided as-is, no SLA — use at your own risk.",
   "homepage": "https://venice.ai",
   "license": "MIT",
-  "version": "0.1.1-alpha",
-  "keywords": ["uncensored", "privacy", "crypto", "x402", "image-generation", "video-generation", "tts", "asr", "music", "characters"],
-  "transports": ["stdio"],
+  "version": "0.2.0",
+  "keywords": [
+    "uncensored",
+    "privacy",
+    "crypto",
+    "x402",
+    "image-generation",
+    "video-generation",
+    "tts",
+    "asr",
+    "music",
+    "characters"
+  ],
+  "transports": [
+    "stdio"
+  ],
   "command": {
     "stdio": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.0"],
+      "args": [
+        "-y",
+        "@veniceai/mcp-server"
+      ],
       "env": {
         "VENICE_API_KEY": "${VENICE_API_KEY}",
         "VENICE_SIWX_TOKEN": "${VENICE_SIWX_TOKEN}"

--- a/mcp.json
+++ b/mcp.json
@@ -26,7 +26,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@veniceai/mcp-server"
+        "@veniceai/mcp-server@0.2.0"
       ],
       "env": {
         "VENICE_API_KEY": "${VENICE_API_KEY}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.2-alpha",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@veniceai/mcp-server",
-      "version": "0.1.2-alpha",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veniceai/mcp-server",
-  "version": "0.1.2-alpha",
+  "version": "0.2.0",
   "description": "Model Context Protocol server for Venice.ai — uncensored, private, crypto-native AI inference for Claude, ChatGPT, Cursor and any MCP host. Community-maintained. Provided as-is, with no warranty or SLA from Venice AI. Use at your own risk.",
   "license": "MIT",
   "author": "Venice AI",

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     timeoutMs: parseTimeoutMs(env.VENICE_HTTP_TIMEOUT_MS),
     enableNsfw: env.VENICE_DISABLE_NSFW !== '1',
     serverName: '@veniceai/mcp-server',
-    serverVersion: '0.1.2-alpha',
+    serverVersion: '0.2.0',
   }
 }


### PR DESCRIPTION
## GA release prep

Bumps the package to `0.2.0` and cleans up all alpha artefacts.

## Changes

| File | Change |
|---|---|
| `package.json` / `package-lock.json` | `0.1.2-alpha` → `0.2.0` |
| `src/config.ts` | `serverVersion` → `0.2.0` |
| `README.md` | All 3 `npx` args un-pinned to plain `@veniceai/mcp-server` (picks up `latest`) |
| `mcp.json` | version → `0.2.0`, args un-pinned |
| `.github/workflows/npm-publish.yml` | `--provenance` restored (removed TODO comment) |

## ⚠️ Pre-merge blockers

- [ ] **Repo must be made public** before merging — `--provenance` requires a public GitHub repo or the publish step will fail
- [ ] **Product README review** — team sign-off on copy before GA

## Post-merge steps

1. Create GitHub Release `v0.2.0` (without `--prerelease`) to trigger the publish workflow
2. Fix `latest` dist-tag on npm (currently points to `0.1.0-alpha`) — the workflow will set it correctly on publish
3. Submit to Smithery (`smithery.yaml` is ready)
4. Marketplace submissions
5. Close Linear API-8