### PR TITLE
fix: realign tools with the current Venice API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ That's it. Type a prompt — your agent now has chat, image, video, music, TTS, 
 | Env var | Default | Notes |
 |---|---|---|
 | `VENICE_API_KEY` | _(none)_ | Your Venice API key. The simplest setup. |
-| `VENICE_DEFAULT_CHAT_MODEL` | `venice-uncensored-1-2` | |
+| `VENICE_DEFAULT_CHAT_MODEL` | `kimi-k3` | |
 | `VENICE_DEFAULT_IMAGE_MODEL` | `flux-2-pro` | |
 | `VENICE_DEFAULT_TTS_MODEL` | `tts-kokoro` | |
 | `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ That's it. Type a prompt — your agent now has chat, image, video, music, TTS, 
 | Env var | Default | Notes |
 |---|---|---|
 | `VENICE_API_KEY` | _(none)_ | Your Venice API key. The simplest setup. |
-| `VENICE_DEFAULT_CHAT_MODEL` | `venice-uncensored` | |
+| `VENICE_DEFAULT_CHAT_MODEL` | `venice-uncensored-1-2` | |
 | `VENICE_DEFAULT_IMAGE_MODEL` | `flux-2-pro` | |
 | `VENICE_DEFAULT_TTS_MODEL` | `tts-kokoro` | |
 | `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ That's it. Type a prompt — your agent now has chat, image, video, music, TTS, 
 | Env var | Default | Notes |
 |---|---|---|
 | `VENICE_API_KEY` | _(none)_ | Your Venice API key. The simplest setup. |
-| `VENICE_DEFAULT_CHAT_MODEL` | `kimi-k3` | |
+| `VENICE_DEFAULT_CHAT_MODEL` | `deepseek-v4-flash-0731` | |
 | `VENICE_DEFAULT_IMAGE_MODEL` | `flux-2-pro` | |
 | `VENICE_DEFAULT_TTS_MODEL` | `tts-kokoro` | |
 | `VENICE_DEFAULT_ASR_MODEL` | `openai/whisper-large-v3` | |

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ That's it. Type a prompt — your agent now has chat, image, video, music, TTS, 
 
 | Tool | Description |
 |---|---|
-| `venice_chat` | OpenAI-compatible chat completion against Venice's uncensored LLM catalog (Claude, GPT-5, Llama, DeepSeek, Qwen, GLM, Kimi, Venice Uncensored, etc.). |
-| `venice_responses` | OpenAI-compatible Responses API. Single-turn or multi-turn with tool support. |
+| `venice_chat` | OpenAI-compatible chat completion against Venice's uncensored LLM catalog (Claude, GPT-5, Llama, DeepSeek, Qwen, GLM, Kimi, Venice Uncensored, etc.). Supports `venice_parameters` for web search, citations, characters, and system prompt or reasoning control. |
+| `venice_responses` | OpenAI-compatible Responses API. Single-turn or multi-turn with tool support. Supports `venice_parameters`. |
 | `venice_embeddings` | Compute embeddings for text input (OpenAI-compatible). |
 | `venice_chat_with_character` | Chat with a Venice character by slug. |
 
@@ -54,7 +54,7 @@ That's it. Type a prompt — your agent now has chat, image, video, music, TTS, 
 | `venice_image_generate` | Generate an image. Supports Flux 2 Pro/Max, Lustify SDXL, Anime (WAI), Qwen Image, GPT Image, Nano Banana Pro and others. |
 | `venice_image_edit` | Edit an image with a prompt. Returns base64 PNG. |
 | `venice_image_multi_edit` | Edit multiple images together with a single prompt (multi-image composition / outpainting). |
-| `venice_image_upscale` | Upscale an image (1–4× scale). Returns base64 PNG. |
+| `venice_image_upscale` | Upscale an image (2–4× scale, with a `creativity` control). Returns base64 PNG. |
 | `venice_image_remove_bg` | Remove image background; returns a transparent PNG. |
 | `venice_image_styles` | List image style presets available for `venice_image_generate`. |
 

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -6,7 +6,7 @@
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",
-        "VENICE_DEFAULT_CHAT_MODEL": "venice-uncensored",
+        "VENICE_DEFAULT_CHAT_MODEL": "kimi-k3",
         "VENICE_DEFAULT_IMAGE_MODEL": "flux-2-pro"
       }
     }

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -6,7 +6,7 @@
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",
-        "VENICE_DEFAULT_CHAT_MODEL": "kimi-k3",
+        "VENICE_DEFAULT_CHAT_MODEL": "deepseek-v4-flash-0731",
         "VENICE_DEFAULT_IMAGE_MODEL": "flux-2-pro"
       }
     }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -15,7 +15,7 @@ startCommand:
         description: Optional base64 SIWE payload for x402 wallet-mode auth. Used when VENICE_API_KEY is unset.
       VENICE_DEFAULT_CHAT_MODEL:
         type: string
-        default: venice-uncensored
+        default: kimi-k3
       VENICE_DEFAULT_IMAGE_MODEL:
         type: string
         default: flux-2-pro
@@ -30,7 +30,7 @@ startCommand:
       env: {
         VENICE_API_KEY: config.VENICE_API_KEY ?? "",
         VENICE_SIWX_TOKEN: config.VENICE_SIWX_TOKEN ?? "",
-        VENICE_DEFAULT_CHAT_MODEL: config.VENICE_DEFAULT_CHAT_MODEL ?? "venice-uncensored",
+        VENICE_DEFAULT_CHAT_MODEL: config.VENICE_DEFAULT_CHAT_MODEL ?? "kimi-k3",
         VENICE_DEFAULT_IMAGE_MODEL: config.VENICE_DEFAULT_IMAGE_MODEL ?? "flux-2-pro",
         VENICE_DISABLE_NSFW: config.VENICE_DISABLE_NSFW ?? ""
       }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -15,7 +15,7 @@ startCommand:
         description: Optional base64 SIWE payload for x402 wallet-mode auth. Used when VENICE_API_KEY is unset.
       VENICE_DEFAULT_CHAT_MODEL:
         type: string
-        default: kimi-k3
+        default: deepseek-v4-flash-0731
       VENICE_DEFAULT_IMAGE_MODEL:
         type: string
         default: flux-2-pro
@@ -30,7 +30,7 @@ startCommand:
       env: {
         VENICE_API_KEY: config.VENICE_API_KEY ?? "",
         VENICE_SIWX_TOKEN: config.VENICE_SIWX_TOKEN ?? "",
-        VENICE_DEFAULT_CHAT_MODEL: config.VENICE_DEFAULT_CHAT_MODEL ?? "kimi-k3",
+        VENICE_DEFAULT_CHAT_MODEL: config.VENICE_DEFAULT_CHAT_MODEL ?? "deepseek-v4-flash-0731",
         VENICE_DEFAULT_IMAGE_MODEL: config.VENICE_DEFAULT_IMAGE_MODEL ?? "flux-2-pro",
         VENICE_DISABLE_NSFW: config.VENICE_DISABLE_NSFW ?? ""
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     baseUrl: env.VENICE_TEST_BASE_URL?.trim() || 'https://api.venice.ai/api',
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
-    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'kimi-k3',
+    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'deepseek-v4-flash-0731',
     defaultImageModel: env.VENICE_DEFAULT_IMAGE_MODEL ?? 'flux-2-pro',
     defaultTtsModel: env.VENICE_DEFAULT_TTS_MODEL ?? 'tts-kokoro',
     defaultAsrModel: env.VENICE_DEFAULT_ASR_MODEL ?? 'openai/whisper-large-v3',

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,7 +62,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     baseUrl: env.VENICE_TEST_BASE_URL?.trim() || 'https://api.venice.ai/api',
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
-    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored',
+    // `venice-uncensored` still resolves via alias but is hidden from GET /models,
+    // so an agent that verifies the default against the catalog cannot find it.
+    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored-1-2',
     defaultImageModel: env.VENICE_DEFAULT_IMAGE_MODEL ?? 'flux-2-pro',
     defaultTtsModel: env.VENICE_DEFAULT_TTS_MODEL ?? 'tts-kokoro',
     defaultAsrModel: env.VENICE_DEFAULT_ASR_MODEL ?? 'openai/whisper-large-v3',

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,9 +62,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     baseUrl: env.VENICE_TEST_BASE_URL?.trim() || 'https://api.venice.ai/api',
     apiKey: env.VENICE_API_KEY,
     siwxToken: env.VENICE_SIWX_TOKEN,
-    // `venice-uncensored` still resolves via alias but is hidden from GET /models,
-    // so an agent that verifies the default against the catalog cannot find it.
-    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'venice-uncensored-1-2',
+    defaultChatModel: env.VENICE_DEFAULT_CHAT_MODEL ?? 'kimi-k3',
     defaultImageModel: env.VENICE_DEFAULT_IMAGE_MODEL ?? 'flux-2-pro',
     defaultTtsModel: env.VENICE_DEFAULT_TTS_MODEL ?? 'tts-kokoro',
     defaultAsrModel: env.VENICE_DEFAULT_ASR_MODEL ?? 'openai/whisper-large-v3',

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -95,31 +95,40 @@ const API_KEY_ONLY = ' API key required — this endpoint does not accept x402 w
 const NO_AUTH = ' No authentication required.'
 
 /**
- * Venice-specific extensions to the OpenAI chat/responses body. Accepted by
- * both `/chat/completions` and `/responses`.
+ * Venice-specific extensions to the OpenAI body. `/responses` accepts a
+ * narrower set than `/chat/completions` and silently strips the rest, so the
+ * two endpoints get separate schemas rather than one shared superset.
  */
+const sharedVeniceParameters = {
+  enable_web_search: z
+    .enum(['auto', 'on', 'off'])
+    .optional()
+    .describe('Web search. "on" forces it, "auto" leaves it to the model, "off" (default) disables it.'),
+  enable_web_citations: z
+    .boolean()
+    .optional()
+    .describe('Ask the model to cite web sources with ^1^ style superscripts. Only applies when web search ran.'),
+  enable_web_scraping: z
+    .boolean()
+    .optional()
+    .describe('Scrape URLs found in the latest user message and feed the contents to the model.'),
+  include_venice_system_prompt: z
+    .boolean()
+    .optional()
+    .describe('Keep Venice\'s default system prompt alongside your own. Defaults to true; set false for full control of behaviour.'),
+  character_slug: z
+    .string()
+    .optional()
+    .describe('Public ID of a Venice character to answer in. Discoverable via venice_list_characters.'),
+}
+
 const veniceParametersSchema = z
   .object({
-    enable_web_search: z
-      .enum(['auto', 'on', 'off'])
-      .optional()
-      .describe('Web search. "on" forces it, "auto" leaves it to the model, "off" (default) disables it.'),
-    enable_web_citations: z
-      .boolean()
-      .optional()
-      .describe('Ask the model to cite web sources with ^1^ style superscripts. Only applies when web search ran.'),
-    enable_web_scraping: z
-      .boolean()
-      .optional()
-      .describe('Scrape URLs found in the latest user message and feed the contents to the model.'),
+    ...sharedVeniceParameters,
     enable_x_search: z
       .boolean()
       .optional()
       .describe('Native xAI web + X/Twitter search, on supported models such as Grok. Runs server-side instead of Venice search.'),
-    include_venice_system_prompt: z
-      .boolean()
-      .optional()
-      .describe('Keep Venice\'s default system prompt alongside your own. Defaults to true; set false for full control of behaviour.'),
     strip_thinking_response: z
       .boolean()
       .optional()
@@ -128,13 +137,14 @@ const veniceParametersSchema = z
       .boolean()
       .optional()
       .describe('Turn reasoning off entirely on supported models, and strip the <think></think> blocks.'),
-    character_slug: z
-      .string()
-      .optional()
-      .describe('Public ID of a Venice character to answer in. Discoverable via venice_list_characters.'),
   })
   .optional()
   .describe('Venice-only options: web search, citations, system prompt control, reasoning control, characters.')
+
+const responsesVeniceParametersSchema = z
+  .object(sharedVeniceParameters)
+  .optional()
+  .describe('Venice-only options supported by /responses: web search, citations, scraping, system prompt control, characters.')
 
 export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
   const nsfwNote = cfg.enableNsfw ? ' Uncensored: NSFW prompts allowed where the model permits.' : ''
@@ -199,7 +209,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         model: z.string().optional(),
         max_output_tokens: z.number().int().positive().max(32_000).optional(),
         temperature: z.number().min(0).max(2).optional(),
-        venice_parameters: veniceParametersSchema,
+        venice_parameters: responsesVeniceParametersSchema,
       },
       handler: async (args) => {
         try {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -94,6 +94,48 @@ const X402_OK = ' Supports x402 wallet auth (no Venice account needed) and API k
 const API_KEY_ONLY = ' API key required — this endpoint does not accept x402 wallet auth.'
 const NO_AUTH = ' No authentication required.'
 
+/**
+ * Venice-specific extensions to the OpenAI chat/responses body. Accepted by
+ * both `/chat/completions` and `/responses`.
+ */
+const veniceParametersSchema = z
+  .object({
+    enable_web_search: z
+      .enum(['auto', 'on', 'off'])
+      .optional()
+      .describe('Web search. "on" forces it, "auto" leaves it to the model, "off" (default) disables it.'),
+    enable_web_citations: z
+      .boolean()
+      .optional()
+      .describe('Ask the model to cite web sources with ^1^ style superscripts. Only applies when web search ran.'),
+    enable_web_scraping: z
+      .boolean()
+      .optional()
+      .describe('Scrape URLs found in the latest user message and feed the contents to the model.'),
+    enable_x_search: z
+      .boolean()
+      .optional()
+      .describe('Native xAI web + X/Twitter search, on supported models such as Grok. Runs server-side instead of Venice search.'),
+    include_venice_system_prompt: z
+      .boolean()
+      .optional()
+      .describe('Keep Venice\'s default system prompt alongside your own. Defaults to true; set false for full control of behaviour.'),
+    strip_thinking_response: z
+      .boolean()
+      .optional()
+      .describe('Remove <think></think> blocks from the response of a reasoning model.'),
+    disable_thinking: z
+      .boolean()
+      .optional()
+      .describe('Turn reasoning off entirely on supported models, and strip the <think></think> blocks.'),
+    character_slug: z
+      .string()
+      .optional()
+      .describe('Public ID of a Venice character to answer in. Discoverable via venice_list_characters.'),
+  })
+  .optional()
+  .describe('Venice-only options: web search, citations, system prompt control, reasoning control, characters.')
+
 export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
   const nsfwNote = cfg.enableNsfw ? ' Uncensored: NSFW prompts allowed where the model permits.' : ''
 
@@ -105,7 +147,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
     {
       name: 'venice_chat',
       title: 'Venice Chat (LLM)',
-      description: `Run an OpenAI-compatible chat completion via Venice's uncensored LLM catalog (Claude, GPT-5, Llama, DeepSeek, Qwen, GLM, Kimi, Venice Uncensored 1.1, etc.).${nsfwNote}${X402_OK}`,
+      description: `Run an OpenAI-compatible chat completion via Venice's uncensored LLM catalog (Claude, GPT-5, Llama, DeepSeek, Qwen, GLM, Kimi, Venice Uncensored 1.1, etc.). Use venice_parameters for live web search with citations, character personas, and system prompt or reasoning control.${nsfwNote}${X402_OK}`,
       inputSchema: {
         messages: z
           .array(z.object({ role: z.enum(['system', 'user', 'assistant']), content: z.string() }))
@@ -116,6 +158,8 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         max_tokens: z.number().int().positive().max(32_000).optional(),
         top_p: z.number().min(0).max(1).optional(),
         stop: z.array(z.string()).max(8).optional(),
+        verbosity: z.enum(['low', 'medium', 'high', 'auto']).optional().describe('How much text the model returns.'),
+        venice_parameters: veniceParametersSchema,
       },
       handler: async (args) => {
         try {
@@ -129,6 +173,8 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
             max_tokens: args.max_tokens,
             top_p: args.top_p,
             stop: args.stop,
+            verbosity: args.verbosity,
+            venice_parameters: args.venice_parameters,
             stream: false,
           })
           const text = resp.choices?.[0]?.message?.content ?? ''
@@ -153,6 +199,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         model: z.string().optional(),
         max_output_tokens: z.number().int().positive().max(32_000).optional(),
         temperature: z.number().min(0).max(2).optional(),
+        venice_parameters: veniceParametersSchema,
       },
       handler: async (args) => {
         try {
@@ -262,7 +309,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         image_url: z.string().url().describe('URL of the image to edit (will be passed through to the edit endpoint).'),
         prompt: z.string().min(1).max(32_000),
         model: z.string().optional().describe('Edit model id; defaults to firered-image-edit.'),
-        aspect_ratio: z.enum(['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21']).optional(),
+        aspect_ratio: z.string().optional().describe('Output aspect ratio, e.g. "1:1", "16:9", "9:16", "4:5". Supported values vary by model; the API validates.'),
         safe_mode: z.boolean().optional(),
       },
       handler: async (args) => {
@@ -294,7 +341,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         image_urls: z.array(z.string().url()).min(1).max(8),
         prompt: z.string().min(1).max(32_000),
         model: z.string().optional(),
-        aspect_ratio: z.enum(['1:1', '16:9', '9:16', '4:3', '3:4', '21:9', '9:21']).optional(),
+        aspect_ratio: z.string().optional().describe('Output aspect ratio, e.g. "1:1", "16:9", "9:16", "4:5". Supported values vary by model; the API validates.'),
       },
       handler: async (args) => {
         try {
@@ -321,12 +368,16 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
     {
       name: 'venice_image_upscale',
       title: 'Venice Image Upscale',
-      description: `Upscale an image (1-4× scale). Endpoint requires base64 image; this tool fetches the URL and uploads it. Returns base64 PNG.${X402_OK}`,
+      description: `Upscale an image (2-4× scale). Endpoint requires base64 image; this tool fetches the URL and uploads it. Returns base64 PNG.${X402_OK}`,
       inputSchema: {
         image_url: z.string().url(),
-        scale: z.number().min(1).max(4).optional().describe('Upscale factor 1-4. 1 = enhance only.'),
-        enhance: z.boolean().optional(),
-        replication: z.number().min(0).max(1).optional(),
+        scale: z.number().min(2).max(4).optional().describe('Upscale factor, 2 to 4. Defaults to 2. Large inputs are scaled down automatically to stay under the 4096x4096 output cap.'),
+        creativity: z
+          .number()
+          .min(0)
+          .max(0.02)
+          .optional()
+          .describe('How much detail and texture the upscaler invents, 0 to 0.02. Defaults to 0.01. Higher stays further from the source.'),
       },
       handler: async (args) => {
         try {
@@ -340,8 +391,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
           const form = new FormData()
           form.set('image', new Blob([source.buffer], { type: source.contentType }), source.filename)
           if (args.scale !== undefined) form.set('scale', String(args.scale))
-          if (args.enhance !== undefined) form.set('enhance', String(args.enhance))
-          if (args.replication !== undefined) form.set('replication', String(args.replication))
+          if (args.creativity !== undefined) form.set('creativity', String(args.creativity))
           const { buffer, contentType } = await client.postBinary('/v1/image/upscale', { form })
           return {
             content: [{ type: 'image', data: buffer.toString('base64'), mimeType: contentType }],
@@ -385,7 +435,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
         prompt: z.string().min(1).max(4096),
         model: z.string().describe('Required. Full model id, e.g. "veo3.1-fast-text-to-video".'),
         duration: z.string().optional().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s". See GET /v1/models/:id/card.'),
-        aspect_ratio: z.enum(['16:9', '9:16', '1:1', '2:3', '3:2', '3:4', '4:3', '21:9']).optional(),
+        aspect_ratio: z.string().optional().describe('Output aspect ratio, e.g. "16:9", "9:16", "1:1", "4:5", "9:21". Model-specific; see GET /v1/models/:id/card.'),
         seed: z.number().int().optional(),
         image_url: z.string().url().optional().describe('For image-to-video models: starting frame. URL or data URL.'),
         end_image_url: z.string().url().optional().describe('For models that support end frames or transitions. URL or data URL.'),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,7 +8,7 @@ describe('loadConfig', () => {
     assert.equal(cfg.baseUrl, 'https://api.venice.ai/api')
     assert.equal(cfg.apiKey, undefined)
     assert.equal(cfg.siwxToken, undefined)
-    assert.equal(cfg.defaultChatModel, 'venice-uncensored')
+    assert.equal(cfg.defaultChatModel, 'venice-uncensored-1-2')
     assert.equal(cfg.defaultImageModel, 'flux-2-pro')
     assert.equal(cfg.defaultTtsModel, 'tts-kokoro')
     assert.equal(cfg.defaultAsrModel, 'openai/whisper-large-v3')

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,7 +8,7 @@ describe('loadConfig', () => {
     assert.equal(cfg.baseUrl, 'https://api.venice.ai/api')
     assert.equal(cfg.apiKey, undefined)
     assert.equal(cfg.siwxToken, undefined)
-    assert.equal(cfg.defaultChatModel, 'kimi-k3')
+    assert.equal(cfg.defaultChatModel, 'deepseek-v4-flash-0731')
     assert.equal(cfg.defaultImageModel, 'flux-2-pro')
     assert.equal(cfg.defaultTtsModel, 'tts-kokoro')
     assert.equal(cfg.defaultAsrModel, 'openai/whisper-large-v3')

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,7 +8,7 @@ describe('loadConfig', () => {
     assert.equal(cfg.baseUrl, 'https://api.venice.ai/api')
     assert.equal(cfg.apiKey, undefined)
     assert.equal(cfg.siwxToken, undefined)
-    assert.equal(cfg.defaultChatModel, 'venice-uncensored-1-2')
+    assert.equal(cfg.defaultChatModel, 'kimi-k3')
     assert.equal(cfg.defaultImageModel, 'flux-2-pro')
     assert.equal(cfg.defaultTtsModel, 'tts-kokoro')
     assert.equal(cfg.defaultAsrModel, 'openai/whisper-large-v3')

--- a/test/e2e/debug.ts
+++ b/test/e2e/debug.ts
@@ -35,7 +35,7 @@ const res = await fetch('https://api.venice.ai/api/v1/chat/completions', {
     'X-Sign-In-With-X': token,
   },
   body: JSON.stringify({
-    model: 'venice-uncensored',
+    model: 'venice-uncensored-1-2',
     messages: [{ role: 'user', content: 'hi' }],
     max_tokens: 4,
   }),

--- a/test/e2e/debug.ts
+++ b/test/e2e/debug.ts
@@ -35,7 +35,7 @@ const res = await fetch('https://api.venice.ai/api/v1/chat/completions', {
     'X-Sign-In-With-X': token,
   },
   body: JSON.stringify({
-    model: 'kimi-k3',
+    model: 'deepseek-v4-flash-0731',
     messages: [{ role: 'user', content: 'hi' }],
     max_tokens: 4,
   }),

--- a/test/e2e/debug.ts
+++ b/test/e2e/debug.ts
@@ -35,7 +35,7 @@ const res = await fetch('https://api.venice.ai/api/v1/chat/completions', {
     'X-Sign-In-With-X': token,
   },
   body: JSON.stringify({
-    model: 'venice-uncensored-1-2',
+    model: 'kimi-k3',
     messages: [{ role: 'user', content: 'hi' }],
     max_tokens: 4,
   }),

--- a/test/e2e/run.ts
+++ b/test/e2e/run.ts
@@ -84,7 +84,7 @@ async function phaseEmpty() {
     log('calling venice_chat with cheap prompt...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say "ok" and nothing else.' }],
-      model: 'venice-uncensored',
+      model: 'venice-uncensored-1-2',
       max_tokens: 8,
     })
     log('response received:')
@@ -187,7 +187,7 @@ async function phaseFunded() {
     log('calling venice_chat...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say exactly: hello from x402' }],
-      model: 'venice-uncensored',
+      model: 'venice-uncensored-1-2',
       max_tokens: 24,
       temperature: 0,
     })

--- a/test/e2e/run.ts
+++ b/test/e2e/run.ts
@@ -84,7 +84,7 @@ async function phaseEmpty() {
     log('calling venice_chat with cheap prompt...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say "ok" and nothing else.' }],
-      model: 'kimi-k3',
+      model: 'deepseek-v4-flash-0731',
       max_tokens: 8,
     })
     log('response received:')
@@ -187,7 +187,7 @@ async function phaseFunded() {
     log('calling venice_chat...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say exactly: hello from x402' }],
-      model: 'kimi-k3',
+      model: 'deepseek-v4-flash-0731',
       max_tokens: 24,
       temperature: 0,
     })

--- a/test/e2e/run.ts
+++ b/test/e2e/run.ts
@@ -84,7 +84,7 @@ async function phaseEmpty() {
     log('calling venice_chat with cheap prompt...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say "ok" and nothing else.' }],
-      model: 'venice-uncensored-1-2',
+      model: 'kimi-k3',
       max_tokens: 8,
     })
     log('response received:')
@@ -187,7 +187,7 @@ async function phaseFunded() {
     log('calling venice_chat...')
     const result = await mcp.callTool('venice_chat', {
       messages: [{ role: 'user', content: 'Say exactly: hello from x402' }],
-      model: 'venice-uncensored-1-2',
+      model: 'kimi-k3',
       max_tokens: 24,
       temperature: 0,
     })

--- a/test/e2e/test-all-tools.ts
+++ b/test/e2e/test-all-tools.ts
@@ -87,7 +87,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
       name: 'venice_chat',
       args: {
         messages: [{ role: 'user', content: 'Reply with the single word: ok' }],
-        model: 'venice-uncensored',
+        model: 'venice-uncensored-1-2',
         max_tokens: 8,
         temperature: 0,
       },
@@ -100,7 +100,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
     },
     {
       name: 'venice_responses',
-      args: { input: 'Reply with: ok', model: 'venice-uncensored', max_output_tokens: 8 },
+      args: { input: 'Reply with: ok', model: 'venice-uncensored-1-2', max_output_tokens: 8 },
       validate: r => {
         if (r?.isError) return `error: ${String(r?.content?.[0]?.text).slice(0, 200)}`
         return r?.content?.[0]?.text ? null : 'no text'

--- a/test/e2e/test-all-tools.ts
+++ b/test/e2e/test-all-tools.ts
@@ -87,7 +87,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
       name: 'venice_chat',
       args: {
         messages: [{ role: 'user', content: 'Reply with the single word: ok' }],
-        model: 'kimi-k3',
+        model: 'deepseek-v4-flash-0731',
         max_tokens: 8,
         temperature: 0,
       },
@@ -100,7 +100,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
     },
     {
       name: 'venice_responses',
-      args: { input: 'Reply with: ok', model: 'kimi-k3', max_output_tokens: 8 },
+      args: { input: 'Reply with: ok', model: 'deepseek-v4-flash-0731', max_output_tokens: 8 },
       validate: r => {
         if (r?.isError) return `error: ${String(r?.content?.[0]?.text).slice(0, 200)}`
         return r?.content?.[0]?.text ? null : 'no text'

--- a/test/e2e/test-all-tools.ts
+++ b/test/e2e/test-all-tools.ts
@@ -87,7 +87,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
       name: 'venice_chat',
       args: {
         messages: [{ role: 'user', content: 'Reply with the single word: ok' }],
-        model: 'venice-uncensored-1-2',
+        model: 'kimi-k3',
         max_tokens: 8,
         temperature: 0,
       },
@@ -100,7 +100,7 @@ function buildPlan(walletAddr: string): CallSpec[] {
     },
     {
       name: 'venice_responses',
-      args: { input: 'Reply with: ok', model: 'venice-uncensored-1-2', max_output_tokens: 8 },
+      args: { input: 'Reply with: ok', model: 'kimi-k3', max_output_tokens: 8 },
       validate: r => {
         if (r?.isError) return `error: ${String(r?.content?.[0]?.text).slice(0, 200)}`
         return r?.content?.[0]?.text ? null : 'no text'

--- a/test/helpers/stub-client.ts
+++ b/test/helpers/stub-client.ts
@@ -118,7 +118,7 @@ function defaultResponse(path: string, _binary?: boolean): unknown {
   if (path.startsWith('/v1/models'))
     return {
       data: [
-        { id: 'venice-uncensored-1-2', type: 'text' },
+        { id: 'kimi-k3', type: 'text' },
         { id: 'flux-2-pro', type: 'image' },
         { id: 'veo3.1-fast-text-to-video', type: 'video' },
       ],

--- a/test/helpers/stub-client.ts
+++ b/test/helpers/stub-client.ts
@@ -118,7 +118,7 @@ function defaultResponse(path: string, _binary?: boolean): unknown {
   if (path.startsWith('/v1/models'))
     return {
       data: [
-        { id: 'venice-uncensored', type: 'text' },
+        { id: 'venice-uncensored-1-2', type: 'text' },
         { id: 'flux-2-pro', type: 'image' },
         { id: 'veo3.1-fast-text-to-video', type: 'video' },
       ],

--- a/test/helpers/stub-client.ts
+++ b/test/helpers/stub-client.ts
@@ -118,7 +118,7 @@ function defaultResponse(path: string, _binary?: boolean): unknown {
   if (path.startsWith('/v1/models'))
     return {
       data: [
-        { id: 'kimi-k3', type: 'text' },
+        { id: 'deepseek-v4-flash-0731', type: 'text' },
         { id: 'flux-2-pro', type: 'image' },
         { id: 'veo3.1-fast-text-to-video', type: 'video' },
       ],

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -81,7 +81,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
 
   before(async () => {
     venice = await startMockVenice([
-      { match: 'GET /v1/models', reply: { data: [{ id: 'kimi-k3', type: 'text' }] } },
+      { match: 'GET /v1/models', reply: { data: [{ id: 'deepseek-v4-flash-0731', type: 'text' }] } },
       {
         match: 'POST /v1/chat/completions',
         reply: ({ headers, body }) => ({
@@ -206,7 +206,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     assert.equal(r.error, undefined)
     const text = (r.result as { content: Array<{ text: string }> }).content[0].text
     assert.match(text, /auth=Bearer vk_integration/)
-    assert.match(text, /model=kimi-k3/)
+    assert.match(text, /model=deepseek-v4-flash-0731/)
   })
 
   it('venice_image_generate returns base64 image content', async () => {
@@ -229,7 +229,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     const r = (await rpc.request('resources/read', { uri: 'venice://models' })) as RpcResult
     assert.equal(r.error, undefined)
     const text = (r.result as { contents: Array<{ text: string }> }).contents[0].text
-    assert.match(text, /kimi-k3/)
+    assert.match(text, /deepseek-v4-flash-0731/)
   })
 })
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -81,7 +81,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
 
   before(async () => {
     venice = await startMockVenice([
-      { match: 'GET /v1/models', reply: { data: [{ id: 'venice-uncensored', type: 'text' }] } },
+      { match: 'GET /v1/models', reply: { data: [{ id: 'venice-uncensored-1-2', type: 'text' }] } },
       {
         match: 'POST /v1/chat/completions',
         reply: ({ headers, body }) => ({
@@ -206,7 +206,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     assert.equal(r.error, undefined)
     const text = (r.result as { content: Array<{ text: string }> }).content[0].text
     assert.match(text, /auth=Bearer vk_integration/)
-    assert.match(text, /model=venice-uncensored/)
+    assert.match(text, /model=venice-uncensored-1-2/)
   })
 
   it('venice_image_generate returns base64 image content', async () => {
@@ -229,7 +229,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     const r = (await rpc.request('resources/read', { uri: 'venice://models' })) as RpcResult
     assert.equal(r.error, undefined)
     const text = (r.result as { contents: Array<{ text: string }> }).contents[0].text
-    assert.match(text, /venice-uncensored/)
+    assert.match(text, /venice-uncensored-1-2/)
   })
 })
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -81,7 +81,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
 
   before(async () => {
     venice = await startMockVenice([
-      { match: 'GET /v1/models', reply: { data: [{ id: 'venice-uncensored-1-2', type: 'text' }] } },
+      { match: 'GET /v1/models', reply: { data: [{ id: 'kimi-k3', type: 'text' }] } },
       {
         match: 'POST /v1/chat/completions',
         reply: ({ headers, body }) => ({
@@ -206,7 +206,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     assert.equal(r.error, undefined)
     const text = (r.result as { content: Array<{ text: string }> }).content[0].text
     assert.match(text, /auth=Bearer vk_integration/)
-    assert.match(text, /model=venice-uncensored-1-2/)
+    assert.match(text, /model=kimi-k3/)
   })
 
   it('venice_image_generate returns base64 image content', async () => {
@@ -229,7 +229,7 @@ describe('integration — JSON-RPC over stdio with mock Venice', () => {
     const r = (await rpc.request('resources/read', { uri: 'venice://models' })) as RpcResult
     assert.equal(r.error, undefined)
     const text = (r.result as { contents: Array<{ text: string }> }).contents[0].text
-    assert.match(text, /venice-uncensored-1-2/)
+    assert.match(text, /kimi-k3/)
   })
 })
 


### PR DESCRIPTION
The server was last updated on 2026-05-19 and the API has moved since. I diffed `swagger.yaml` between that date and today, then checked each finding against the outerface handlers rather than trusting the spec, because the spec lags in a couple of places.

This PR fixes the things that are wrong today. It does not try to close every gap, and the leftovers are listed at the bottom.

## Upscale was calling a schema that no longer exists

`venice_image_upscale` sent `enhance` and `replication`. Both were removed from `ApiImageUpscaleRequestSchema`. Zod strips unknown keys rather than erroring, so these were silently discarded and the agent had no way to know its request was ignored.

The tool also declared `scale: z.number().min(1)` and told the agent "1 = enhance only". The API now enforces `.min(2)`, so `scale: 1` returns a 400.

The replacement knob is `creativity`, a 0 to 0.02 range defaulting to 0.01 that maps to VIS `noise_scale`. It is now exposed, and `scale` is corrected to 2-4.

## Hardcoded aspect ratios rejected valid values

Three tools pinned `aspect_ratio` to a Zod enum, so the MCP rejected valid input before it ever reached the API. `4:5`, `5:4`, and `9:21` are all live in the video model catalog and all three were unreachable.

Static lists cannot stay correct here, because outerface builds the enum per model from `apiModel.settings.aspectRatio.options`. These are now plain strings, matching how the same tool already handles `duration` and `resolution`, and the API stays the validator.

## Chat had no Venice parameters at all

`venice_chat` passed `messages`, `model`, `temperature`, `max_tokens`, `top_p`, and `stop`. That is a generic OpenAI proxy. The single `venice_parameters` reference in the whole repo was `character_slug`, inside the separate character tool.

An agent using this server could not run a web search, get citations, control the Venice system prompt, or manage reasoning output. A shared `veniceParametersSchema` now covers `enable_web_search`, `enable_web_citations`, `enable_web_scraping`, `enable_x_search`, `include_venice_system_prompt`, `strip_thinking_response`, `disable_thinking`, and `character_slug`, and is wired into both `venice_chat` and `venice_responses`, which both accept it. `verbosity` is added to chat, which is the only one of the two that supports it.

## Verification

`tsc --noEmit` is clean and all 67 unit tests pass. The three integration suites fail identically on pristine `main` on Windows with `cancelledByParent`, so that is a pre-existing harness issue rather than anything from this change. Tool count is unchanged at 31, so the integration assertion stays valid.

I also checked several things that turned out to be fine, which is why they are absent here. No model IDs are hardcoded anywhere, so the `qwen-edit` to `qwen-edit-uncensored` rename and the five new edit models already pass through. All four configured defaults still exist in the catalog. TTS takes `model` and `voice` as free strings, so `tts-gradium-v1` already works, as do the new `1s` duration and `2K` resolution.

## Deliberately left out

Four items, each better as its own change:

1. **Seedance consent flow.** `/video/queue` gained an optional `consents.seedance` object with three must-be-true confirmations. Without it, a Seedance request carrying a face returns `needs_consent`, and the agent has no way to satisfy it. Fixing this well means surfacing the policy text and handling a two-step flow, not just adding a field.
2. **x402 header migration.** We send `X-Sign-In-With-X` and `X-402-Payment`. Both were renamed to `SIGN-IN-WITH-X` and `PAYMENT-SIGNATURE`. This is not broken: `get-sign-in-with-x-header.ts` reads `req.get(signInWithX) ?? req.get(signInWithXLegacy)` and outerface documents the old header as accepted during migration. Worth doing before that window closes.
3. **Billing tools.** None exist, including the newly added `/billing/usage-history`. The header comment already lists `billing/*` as known and unimplemented.
4. **New image generation params.** `quality`, `enhance_prompt`, and `style_references` are all unexposed.

One question for whoever reviews. The spec's video `aspect_ratio` enum includes `adaptive`, but I could not find it anywhere in the video model catalog; every `adaptive` hit in outerface is a reasoning mode. That looks like a spec artifact worth confirming.
