### PR TITLE
fix: block IPv4-embedded IPv6 destinations in remote-fetch

### DIFF
--- a/src/tools/remote-fetch.ts
+++ b/src/tools/remote-fetch.ts
@@ -410,19 +410,27 @@ function ipv4sFromEmbeddings(address: string): string[] {
   }
   if (isLocalUseNat64) {
     found.add(last32)
-    const rfc6052 = ipv4FromRfc6052Prefix48(groups)
-    if (rfc6052) found.add(rfc6052)
-    if (![...found].some((ip) => !isBlockedIpv4(ip))) found.add('0.0.0.0')
+    for (const ipv4 of ipv4sFromRfc6052Layouts(groups)) found.add(ipv4)
   }
 
   return [...found]
 }
 
-/** RFC 6052 /48: prefix | v4(16) | u(8)=0 | v4(16) | suffix. */
-function ipv4FromRfc6052Prefix48(groups: number[]): string | undefined {
-  if (((groups[4] >> 8) & 0xff) !== 0) return undefined
-  const ipv4 = `${(groups[3] >> 8) & 0xff}.${groups[3] & 0xff}.${groups[4] & 0xff}.${(groups[5] >> 8) & 0xff}`
-  return ipv4 === '0.0.0.0' ? undefined : ipv4
+/**
+ * RFC 6052 puts IPv4 at a different offset per prefix length, and RFC 8215 reserves
+ * local-use 64:ff9b:1::/48 so operators can carve /56 and /64 translators out of it.
+ * Every layout is decoded and the u octet (bits 64-71) is not required to be zero, so
+ * a malformed address cannot carry a private destination past the check. A candidate
+ * starting at 0 means the wrong offset was read: 0.0.0.0/8 is never a real destination.
+ */
+function ipv4sFromRfc6052Layouts(groups: number[]): string[] {
+  const hi = (group: number) => (group >> 8) & 0xff
+  const lo = (group: number) => group & 0xff
+  return [
+    `${hi(groups[3])}.${lo(groups[3])}.${lo(groups[4])}.${hi(groups[5])}`, // /48
+    `${lo(groups[3])}.${lo(groups[4])}.${hi(groups[5])}.${lo(groups[5])}`, // /56
+    `${lo(groups[4])}.${hi(groups[5])}.${lo(groups[5])}.${hi(groups[6])}`, // /64
+  ].filter((ipv4) => !ipv4.startsWith('0.'))
 }
 
 function expandIpv6Groups(address: string): number[] | undefined {

--- a/src/tools/remote-fetch.ts
+++ b/src/tools/remote-fetch.ts
@@ -87,7 +87,7 @@ async function resolveValidRemoteAddresses(url: URL, lookupAddresses: LookupAddr
     throw new Error(`Refusing to fetch URL with unsupported scheme: ${url.protocol}`)
   }
 
-  const hostname = url.hostname.toLowerCase()
+  const hostname = stripIpv6Brackets(url.hostname.toLowerCase())
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     throw new Error(`Refusing to fetch local hostname: ${url.hostname}`)
   }
@@ -308,10 +308,14 @@ function startsWithAscii(buffer: Buffer, value: string): boolean {
   return buffer.subarray(0, value.length).toString('ascii') === value
 }
 
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname
+}
+
 function isBlockedIp(address: string): boolean {
-  const version = isIP(address)
+  const version = isIP(stripIpv6Brackets(address))
   if (version === 4) return isBlockedIpv4(address)
-  if (version === 6) return isBlockedIpv6(address)
+  if (version === 6) return isBlockedIpv6(stripIpv6Brackets(address))
   return true
 }
 
@@ -335,9 +339,20 @@ function isBlockedIpv4(address: string): boolean {
 }
 
 function isBlockedIpv6(address: string): boolean {
-  const normalized = address.toLowerCase()
-  const mappedIpv4 = normalized.match(/(?:::ffff:)?(\d+\.\d+\.\d+\.\d+)$/)?.[1]
-  if (mappedIpv4 && isBlockedIpv4(mappedIpv4)) return true
+  const normalized = address.toLowerCase().split('%')[0]
+  if (ipv4sFromEmbeddings(normalized).some(isBlockedIpv4)) return true
+
+  const groups = expandIpv6Groups(normalized)
+  if (groups) {
+    const [g0] = groups
+    const isUnspecifiedOrLoopback = groups[0] === 0 && groups.slice(1, 7).every((group) => group === 0) && groups[7] <= 1
+    if (isUnspecifiedOrLoopback) return true
+    if ((g0 & 0xfe00) === 0xfc00) return true // unique local fc00::/7
+    if ((g0 & 0xffc0) === 0xfe80) return true // link-local fe80::/10
+    if ((g0 & 0xffc0) === 0xfec0) return true // deprecated site-local fec0::/10
+    if ((g0 & 0xff00) === 0xff00) return true // multicast ff00::/8
+    return false
+  }
 
   return (
     normalized === '::' ||
@@ -348,6 +363,95 @@ function isBlockedIpv6(address: string): boolean {
     normalized.startsWith('fe9') ||
     normalized.startsWith('fea') ||
     normalized.startsWith('feb') ||
+    normalized.startsWith('fec') ||
     normalized.startsWith('ff')
   )
+}
+
+function ipv4FromHextets(high: number, low: number): string {
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`
+}
+
+/**
+ * Decode IPv4 carried inside IPv6 translation / tunneling forms.
+ * Public embeddings stay allowed; private extracted IPv4s are blocked by the caller.
+ */
+function ipv4sFromEmbeddings(address: string): string[] {
+  const found = new Set<string>()
+  const dotted = address.match(/(\d+\.\d+\.\d+\.\d+)$/)?.[1]
+  if (dotted) found.add(dotted)
+
+  const groups = expandIpv6Groups(address)
+  if (!groups) return [...found]
+
+  const last32 = ipv4FromHextets(groups[6], groups[7])
+  const first96Zero = groups[0] === 0 && groups[1] === 0 && groups[2] === 0 && groups[3] === 0 && groups[4] === 0
+  const isMapped = first96Zero && groups[5] === 0xffff
+  const isCompatible = first96Zero && groups[5] === 0
+  const isTranslated = groups[0] === 0 && groups[1] === 0 && groups[2] === 0 && groups[3] === 0 && groups[4] === 0xffff && groups[5] === 0
+  const isWellKnownNat64 =
+    groups[0] === 0x64 &&
+    groups[1] === 0xff9b &&
+    groups[2] === 0 &&
+    groups[3] === 0 &&
+    groups[4] === 0 &&
+    groups[5] === 0
+  const isLocalUseNat64 = groups[0] === 0x64 && groups[1] === 0xff9b && groups[2] === 0x1
+  const is6to4 = groups[0] === 0x2002
+  const isTeredo = groups[0] === 0x2001 && groups[1] === 0
+  const isIsatap = groups[5] === 0x5efe
+
+  if (isMapped || isCompatible || isTranslated || isWellKnownNat64 || isIsatap) found.add(last32)
+  if (is6to4) found.add(ipv4FromHextets(groups[1], groups[2]))
+  if (isTeredo) {
+    found.add(
+      `${(groups[6] >> 8) ^ 0xff}.${(groups[6] & 0xff) ^ 0xff}.${(groups[7] >> 8) ^ 0xff}.${(groups[7] & 0xff) ^ 0xff}`,
+    )
+  }
+  if (isLocalUseNat64) {
+    found.add(last32)
+    const rfc6052 = ipv4FromRfc6052Prefix48(groups)
+    if (rfc6052) found.add(rfc6052)
+    if (![...found].some((ip) => !isBlockedIpv4(ip))) found.add('0.0.0.0')
+  }
+
+  return [...found]
+}
+
+/** RFC 6052 /48: prefix | v4(16) | u(8)=0 | v4(16) | suffix. */
+function ipv4FromRfc6052Prefix48(groups: number[]): string | undefined {
+  if (((groups[4] >> 8) & 0xff) !== 0) return undefined
+  const ipv4 = `${(groups[3] >> 8) & 0xff}.${groups[3] & 0xff}.${groups[4] & 0xff}.${(groups[5] >> 8) & 0xff}`
+  return ipv4 === '0.0.0.0' ? undefined : ipv4
+}
+
+function expandIpv6Groups(address: string): number[] | undefined {
+  let hex = address
+  const dotted = address.match(/:(\d+\.\d+\.\d+\.\d+)$/)
+  if (dotted) {
+    const parts = dotted[1].split('.').map((part) => Number(part))
+    if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+      return undefined
+    }
+    const hi = ((parts[0] << 8) | parts[1]).toString(16)
+    const lo = ((parts[2] << 8) | parts[3]).toString(16)
+    hex = `${address.slice(0, -dotted[1].length)}${hi}:${lo}`
+  } else if (address.includes('.')) {
+    return undefined
+  }
+
+  const [head, tail] = hex.split('::')
+  const parse = (part: string | undefined) =>
+    part ? part.split(':').filter(Boolean).map((group) => Number.parseInt(group, 16)) : []
+  if (tail === undefined) {
+    const groups = parse(head)
+    return groups.length === 8 && groups.every(Number.isInteger) ? groups : undefined
+  }
+  const left = parse(head)
+  const right = parse(tail)
+  const missing = 8 - left.length - right.length
+  if (missing < 0 || left.some((n) => !Number.isInteger(n)) || right.some((n) => !Number.isInteger(n))) {
+    return undefined
+  }
+  return [...left, ...Array<number>(missing).fill(0), ...right]
 }

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -61,6 +61,75 @@ describe('remote upload fetch security', () => {
     )
   })
 
+  it('rejects IPv4-compatible, mapped, translated, and NAT64 embeddings of private addresses', async () => {
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[::7f00:1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['::7f00:1']),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[::ffff:127.0.0.1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[::ffff:0:7f00:1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['::ffff:0:7f00:1']),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['64:ff9b::7f00:1']),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[64:ff9b:1::7f00:1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[64:ff9b:1:7f00:0:100::]/file.png'), publicLookup),
+      /private or local address/,
+    )
+  })
+
+  it('rejects 6to4, Teredo, ISATAP, and site-local embeddings of private addresses', async () => {
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[2002:7f00:1::]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['2002:a9fe:a9fe::']),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['2001:0:0:0:0:0:80ff:feff']),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[fe80::1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[fec0::1]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['0:0:0:0:0:5efe:7f00:1']),
+      /private or local address/,
+    )
+  })
+
+  it('allows public IPv4 embeddings through compatible, NAT64, and 6to4 forms', async () => {
+    await validateRemoteUrl(new URL('http://[::8c52:d822]/file.png'), publicLookup)
+    await validateRemoteUrl(new URL('https://cdn.example/file.png'), async () => ['::5db8:d822'])
+    await validateRemoteUrl(new URL('https://cdn.example/file.png'), async () => ['64:ff9b:1::5db8:d822'])
+    await validateRemoteUrl(new URL('http://[2002:5db8:d822::]/file.png'), publicLookup)
+  })
+
   it('revalidates redirect targets before following them', async () => {
     const fetchImpl = async () =>
       new Response(null, {

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -96,6 +96,25 @@ describe('remote upload fetch security', () => {
     )
   })
 
+  it('rejects local-use NAT64 /56, /64, and non-zero-u embeddings of private addresses', async () => {
+    // RFC 8215 lets operators carve /56 and /64 translators out of 64:ff9b:1::/48,
+    // so IPv4 can sit at a different offset than the /48 or last-32 layouts.
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[64:ff9b:1:aaaa:7f:0:100:0]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    await assert.rejects(
+      validateRemoteUrl(new URL('http://[64:ff9b:1:7f00:100:100:5db8:d822]/file.png'), publicLookup),
+      /private or local address/,
+    )
+    // /56 layout carrying 10.0.0.1 while the /48 and /64 offsets read as 0.x and the
+    // last 32 bits are public, so only the /56 decode can catch it.
+    await assert.rejects(
+      validateRemoteUrl(new URL('https://internal.example/file.png'), async () => ['64:ff9b:1:a:0:1:5db8:d822']),
+      /private or local address/,
+    )
+  })
+
   it('rejects 6to4, Teredo, ISATAP, and site-local embeddings of private addresses', async () => {
     await assert.rejects(
       validateRemoteUrl(new URL('http://[2002:7f00:1::]/file.png'), publicLookup),
@@ -128,6 +147,9 @@ describe('remote upload fetch security', () => {
     await validateRemoteUrl(new URL('https://cdn.example/file.png'), async () => ['::5db8:d822'])
     await validateRemoteUrl(new URL('https://cdn.example/file.png'), async () => ['64:ff9b:1::5db8:d822'])
     await validateRemoteUrl(new URL('http://[2002:5db8:d822::]/file.png'), publicLookup)
+    // DNS64 through a /64 translator carved out of the local-use prefix: every layout
+    // decodes to a public address, so the extra offsets must not over-block.
+    await validateRemoteUrl(new URL('https://cdn.example/file.png'), async () => ['64:ff9b:1:aaaa:5d:b8d8:2200:0'])
   })
 
   it('revalidates redirect targets before following them', async () => {


### PR DESCRIPTION
## Summary
- Decode IPv4-compatible, mapped, SIIT/translated, well-known NAT64, local-use NAT64, 6to4, Teredo, and ISATAP embeddings in `remote-fetch`.
- Treat Node 24 bracketed IPv6 URL hostnames as literals instead of looking them up.
- Keep public embeddings allowed, except inside the RFC 8215 local-use NAT64 prefix `64:ff9b:1::/48`, where the translator's prefix length is not knowable from the address alone. There every RFC 6052 layout is decoded and the address is blocked if any candidate decodes to a private IPv4, so a minority of public destinations in that prefix are over-blocked. This is deliberate: allowing an address because one candidate is public would let a caller pick the layout and walk a private destination through. Documented in code and pinned by a regression test.
- Feature PRs should not re-implement this.

Closes #49

## Test plan
- [x] `tsx --test test/security.test.ts`
- [x] `tsc --noEmit`


Made with [Cursor](https://cursor.com)
