### PR TITLE
fix: require model for embeddings tool

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -231,7 +231,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
       description: `Compute embeddings for text input (OpenAI-compatible).${X402_OK}`,
       inputSchema: {
         input: z.union([z.string(), z.array(z.string())]).describe('Text or array of texts.'),
-        model: z.string().optional().describe('Embedding model id.'),
+        model: z.string().min(1).describe('Embedding model id.'),
         encoding_format: z.enum(['float', 'base64']).optional(),
       },
       handler: async (args) => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -137,11 +137,16 @@ const MAPPINGS: Mapping[] = [
   },
   {
     tool: 'venice_embeddings',
-    args: { input: 'foo' },
+    args: {
+      input: 'foo',
+      model: 'text-embedding-bge-m3',
+    },
     expectMethod: 'POST',
     expectPath: '/v1/embeddings',
+    expectBodyContains: {
+      model: 'text-embedding-bge-m3',
+    },
   },
-
   // image
   {
     tool: 'venice_image_generate',
@@ -476,5 +481,18 @@ describe('tool output shaping', () => {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+
+  it('requires model for venice_embeddings', () => {
+    const { get } = setup()
+    const tool = get('venice_embeddings')
+
+    const modelSchema = tool.inputSchema.model
+
+    assert.equal(
+      modelSchema.isOptional(),
+      false,
+      'venice_embeddings.model should be required'
+    )
   })
 })


### PR DESCRIPTION
## Summary

* make `model` required for the `venice_embeddings` MCP tool
* reject empty model values with Zod validation
* add regression coverage for the required model field
* update endpoint mapping coverage to verify the model is forwarded

## Testing

* `npx tsx --test --test-name-pattern="requires model for venice_embeddings" test/tools.test.ts`

Closes #52
