### PR TITLE
fix(examples): pin @veniceai/mcp-server@0.2.0 in host configs

### DIFF
--- a/examples/claude-desktop.json
+++ b/examples/claude-desktop.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>"

--- a/examples/cursor.json
+++ b/examples/cursor.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "venice": {
       "command": "npx",
-      "args": ["-y", "@veniceai/mcp-server@0.1.1-alpha"],
+      "args": ["-y", "@veniceai/mcp-server@0.2.0"],
       "env": {
         "VENICE_API_KEY": "<your-venice-api-key>",
         "VENICE_SIWX_TOKEN": "<optional-base64-siwe-payload>",


### PR DESCRIPTION
## What

Both example configs pin `@veniceai/mcp-server@0.1.1-alpha`. The README, the docs site, and `mcp.json` pin `0.2.0`, which is the current `latest` on npm. This updates `examples/claude-desktop.json` and `examples/cursor.json` to `0.2.0`.

## Why

A reader who copies an example gets a pre-release from before GA. 
Nothing else changes.