### PR TITLE
fix: require duration for video tools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -444,7 +444,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
       inputSchema: {
         prompt: z.string().min(1).max(4096),
         model: z.string().describe('Required. Full model id, e.g. "veo3.1-fast-text-to-video".'),
-        duration: z.string().optional().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s". See GET /v1/models/:id/card.'),
+        duration: z.string().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s". See GET /v1/models/:id/card.'),
         aspect_ratio: z.string().optional().describe('Output aspect ratio, e.g. "16:9", "9:16", "1:1", "4:5", "9:21". Model-specific; see GET /v1/models/:id/card.'),
         seed: z.number().int().optional(),
         image_url: z.string().url().optional().describe('For image-to-video models: starting frame. URL or data URL.'),
@@ -935,7 +935,7 @@ export function buildTools(client: VeniceClient, cfg: Config): ToolDef[] {
       description: `Get a price quote for a video generation BEFORE queuing.${NO_AUTH}`,
       inputSchema: {
         model: z.string().min(1).describe('Video model id, e.g. "veo3.1-fast-text-to-video".'),
-        duration: z.string().optional().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s".'),
+        duration: z.string().describe('Duration as model-specific string enum, e.g. "4s", "6s", "8s".'),
       },
       handler: async (args) => {
         try {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { buildTools, type ToolDef } from '../src/tools/index.js'
 import { loadConfig } from '../src/config.js'
 import { StubClient } from './helpers/stub-client.js'
+import { z } from 'zod'
 
 const cfg = loadConfig({ VENICE_API_KEY: 'test-key' })
 
@@ -188,9 +189,17 @@ const MAPPINGS: Mapping[] = [
   // video
   {
     tool: 'venice_video_generate',
-    args: { prompt: 'a sunset' },
+    args: {
+      prompt: 'a sunset',
+      model: 'veo3.1-fast-text-to-video',
+      duration: '8s',
+    },
     expectMethod: 'POST',
     expectPath: '/v1/video/queue',
+    expectBodyContains: {
+      model: 'veo3.1-fast-text-to-video',
+      duration: '8s',
+    },
   },
   {
     tool: 'venice_video_status',
@@ -476,5 +485,55 @@ describe('tool output shaping', () => {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })  
+})
+
+describe('video tool schemas', () => {
+  it('venice_video_generate requires duration', () => {
+    const { get } = setup()
+    const schema = z.object(get('venice_video_generate').inputSchema)
+
+    const result = schema.safeParse({
+      prompt: 'a sunset',
+      model: 'veo3.1-fast-text-to-video',
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  it('venice_video_quote requires duration', () => {
+    const { get } = setup()
+    const schema = z.object(get('venice_video_quote').inputSchema)
+
+    const result = schema.safeParse({
+      model: 'veo3.1-fast-text-to-video',
+    })
+
+    assert.equal(result.success, false)
+  })
+
+  it('accepts duration for venice_video_generate', () => {
+    const { get } = setup()
+    const schema = z.object(get('venice_video_generate').inputSchema)
+
+    const result = schema.safeParse({
+      prompt: 'a sunset',
+      model: 'veo3.1-fast-text-to-video',
+      duration: '8s',
+    })
+
+    assert.equal(result.success, true)
+  })
+
+  it('accepts duration for venice_video_quote', () => {
+    const { get } = setup()
+    const schema = z.object(get('venice_video_quote').inputSchema)
+
+    const result = schema.safeParse({
+      model: 'veo3.1-fast-text-to-video',
+      duration: '8s',
+    })
+
+    assert.equal(result.success, true)
   })
 })


### PR DESCRIPTION
Fixes #55

## Changes
- Make `duration` required for `venice_video_generate`
- Make `duration` required for `venice_video_quote`
- Add regression tests for required duration
- Keep duration as a model-specific string without a hard-coded enum or default

## Testing
- `npm test`

Closes #55